### PR TITLE
refactor: ensure errors with dynamic logging are not swallowed

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build-runner": "tsc",
     "release-build": "tsx release-build.ts",
     "web-codegen-scorer": "tsx ./runner/bin/cli.ts",
+    "wcs": "pnpm -s web-codegen-scorer",
     "eval": "pnpm web-codegen-scorer eval",
     "init": "pnpm web-codegen-scorer init",
     "report": "cd report-app && CODEGEN_REPORTS_DIR=../.web-codegen-scorer/reports pnpm start",

--- a/runner/eval-cli.ts
+++ b/runner/eval-cli.ts
@@ -119,7 +119,12 @@ function builder(argv: Argv): Argv<Options> {
     })
     .option('logging', {
       type: 'string',
-      default: 'dynamic' as const,
+      default:
+        process.env['CI'] === '1'
+          ? ('text-only' as const)
+          : ('dynamic' as const),
+      defaultDescription: '`dynamic` (or `text-only` when `CI=1`)',
+      requiresArg: true,
       choices: ['text-only', 'dynamic'] as const,
       description: 'Type of logging to use during the evaluation process',
     })

--- a/runner/orchestration/generate.ts
+++ b/runner/orchestration/generate.ts
@@ -175,9 +175,9 @@ export async function generateCodeAndAssess(options: {
               stack: e instanceof Error ? e.stack : undefined,
             });
 
-            let details = `  Error: ${e}`;
+            let details = `Error: ${e}`;
             if (e instanceof Error && e.stack) {
-              details += e.stack;
+              details += `\nStack: ${e.stack}`;
             }
 
             progress.log(


### PR DESCRIPTION
Ensures errors printed with dynamic logging are not swallowed. This is easily confusing as the report summary is currently just printed with e.g. zero completed app generations.