### PR TITLE
fix: add error handling for report fetching

### DIFF
--- a/report-app/src/app/app.html
+++ b/report-app/src/app/app.html
@@ -32,8 +32,13 @@
           alt="Loading Web Codegen Scorer Logo"
           class="loading-logo no-animation"
         />
-        <div>No reports available</div>
-        <div>Run <code>web-codegen-scorer eval</code> to generate a report</div>
+
+        @if (groupsError()) {
+          <pre class="callout error code">{{groupsError()}}</pre>
+        } @else {
+          <div>No reports available</div>
+          <div>Run <code>web-codegen-scorer eval</code> to generate a report</div>
+        }
       }
     </div>
   }

--- a/report-app/src/app/app.ts
+++ b/report-app/src/app/app.ts
@@ -18,6 +18,7 @@ export class App {
   protected isLoading = this.reportsFetcher.isLoadingReportsList;
   protected isServer = isPlatformServer(inject(PLATFORM_ID));
   protected colorMode = this.colorModeService.colorMode;
+  protected groupsError = this.reportsFetcher.reportGroupsError;
 
   protected toggleColorMode() {
     this.colorModeService.setColorMode(

--- a/report-app/src/app/pages/report-viewer/report-viewer.html
+++ b/report-app/src/app/pages/report-viewer/report-viewer.html
@@ -137,6 +137,8 @@
 
   @if (isLoading()) {
     <message-spinner message="Loading full report"/>
+  } @else if (error()) {
+    <pre class="callout error code">{{error()?.stack}}</pre>
   } @else if (report) {
     @let details = report.details;
 

--- a/report-app/src/app/pages/report-viewer/report-viewer.ts
+++ b/report-app/src/app/pages/report-viewer/report-viewer.ts
@@ -75,6 +75,7 @@ export class ReportViewer {
   protected reportGroupId = input.required<string>({ alias: 'id' });
   protected formatted = signal<Map<LlmResponseFile, string>>(new Map());
   protected formatScore = formatScore;
+  protected error = computed(() => this.selectedReport.error());
 
   private selectedReport = resource({
     params: () => ({ groupId: this.reportGroupId() }),

--- a/report-app/src/app/shared/styles/callouts.scss
+++ b/report-app/src/app/shared/styles/callouts.scss
@@ -24,5 +24,11 @@
       background-color: #fffbeb;
       border-color: #fef3c7;
     }
+
+    &.error {
+      color: #cd0000;
+      background-color: #ffe7e7;
+      border-color: #df9e9e;
+    }
   }
 }


### PR DESCRIPTION
Currently if fetching data fails, the UI just shows a spinner. These changes add some proper error reporting.