### PR TITLE
fix: context files in prompts not working

### DIFF
--- a/runner/configuration/prompt-templating.ts
+++ b/runner/configuration/prompt-templating.ts
@@ -35,21 +35,10 @@ initializeHandlebars();
 export function renderHandlebarsTemplate<T extends { rootDir: string | null }>(
   content: string,
   ctx: T
-): string {
+) {
   const template = Handlebars.compile(content, { strict: true });
-  return template(ctx);
-}
-
-/**
- * Extracts the context file patterns from a prompt's text. Returns the prompt's text without
- * any special context file syntax and the context file patterns.
- * @param initialPromptText Initial text of the prompt.
- */
-export function extractPromptContextFilePatterns(initialPromptText: string) {
   const contextFiles: string[] = [];
-  const promptText = Handlebars.compile(initialPromptText, {
-    strict: true,
-  })(null, {
+  const result = template(ctx, {
     partials: {
       contextFiles: (ctx) => {
         if (typeof ctx !== 'string') {
@@ -84,7 +73,7 @@ export function extractPromptContextFilePatterns(initialPromptText: string) {
   });
 
   return {
-    promptText,
+    result,
     contextFiles,
   };
 }

--- a/runner/ratings/autoraters/code-rater.ts
+++ b/runner/ratings/autoraters/code-rater.ts
@@ -64,7 +64,7 @@ export async function autoRateCode(
   const prompt = environment.renderPrompt(promptText, null, {
     APP_PROMPT: appPrompt,
     FRAMEWORK_SPECIFIC_HINTS: FW_HINTS[environment.fullStackFramework.id] ?? '',
-  });
+  }).result;
 
   const result = await llm.generateConstrained({
     abortSignal,

--- a/runner/ratings/autoraters/visuals-rater.ts
+++ b/runner/ratings/autoraters/visuals-rater.ts
@@ -31,7 +31,7 @@ export async function autoRateAppearance(
 ): Promise<AutoRateResult> {
   const prompt = environment.renderPrompt(defaultVisualRaterPrompt, null, {
     APP_PROMPT: appPrompt,
-  });
+  }).result;
 
   const messages: PromptDataMessage[] = [
     {


### PR DESCRIPTION
Fixes that the macro for `contextFiles` stopped working.