### PR TITLE
feat: add tool logs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
+      ngx-json-viewer:
+        specifier: ^3.2.1
+        version: 3.2.1
       rxjs:
         specifier: ~7.8.0
         version: 7.8.2
@@ -4968,6 +4971,9 @@ packages:
   netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
+
+  ngx-json-viewer@3.2.1:
+    resolution: {integrity: sha512-TTHtXsrBX+IXPqqAIsxklHPqSNmyGeQaziFZbCDJq1PnPOQmTrEHfwNrzN3LnWGhf7UxeM1cK0njegVPChwEcg==}
 
   node-addon-api@6.1.0:
     resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
@@ -12210,6 +12216,10 @@ snapshots:
   neo-async@2.6.2: {}
 
   netmask@2.0.2: {}
+
+  ngx-json-viewer@3.2.1:
+    dependencies:
+      tslib: 2.8.1
 
   node-addon-api@6.1.0:
     optional: true

--- a/report-app/package.json
+++ b/report-app/package.json
@@ -23,6 +23,7 @@
     "@shikijs/themes": "3.13.0",
     "express": "^4.18.2",
     "jszip": "^3.10.1",
+    "ngx-json-viewer": "^3.2.1",
     "rxjs": "~7.8.0",
     "shiki": "^3.6.0",
     "tinyglobby": "^0.2.14",

--- a/report-app/src/app/pages/report-viewer/report-viewer.html
+++ b/report-app/src/app/pages/report-viewer/report-viewer.html
@@ -411,7 +411,7 @@
                   (click)="downloadDebuggingZip(result)">
                   Download ZIP for debugging
                 </button>
-                @if (result.toolLogs.length > 0) {
+                @if (result.toolLogs && result.toolLogs.length > 0) {
                   <expansion-panel>
                     <expansion-panel-header>Tool Logs</expansion-panel-header>
                     <ul class="tool-logs-list">

--- a/report-app/src/app/pages/report-viewer/report-viewer.html
+++ b/report-app/src/app/pages/report-viewer/report-viewer.html
@@ -411,6 +411,32 @@
                   (click)="downloadDebuggingZip(result)">
                   Download ZIP for debugging
                 </button>
+                @if (result.toolLogs.length > 0) {
+                  <expansion-panel>
+                    <expansion-panel-header>Tool Logs</expansion-panel-header>
+                    <ul class="tool-logs-list">
+                    @for (log of result.toolLogs; track $index) {
+                      <li>
+                        <details class="details mcp-log-entry">
+                          @let name = log.request.name;
+                          <summary>
+                            Log Entry #{{ $index + 1
+                            }}{{ name ? ' - ' + name : '' }}
+                          </summary>
+                          <div class="mcp-log-content">
+                            <h5>Request</h5>
+                            <ngx-json-viewer [json]="log.request" [expanded]="false"></ngx-json-viewer>
+                            <h5>Response</h5>
+                            <ngx-json-viewer [json]="log.response" [expanded]="false"></ngx-json-viewer>
+                          </div>
+                        </details>
+                      </li>
+                    } @empty {
+                      <li>No MCP logs were recorded for this run.</li>
+                    }
+                    </ul>
+                  </expansion-panel>
+                }
               </div>
 
               @if (finalBuild.runtimeErrors) {

--- a/report-app/src/app/pages/report-viewer/report-viewer.scss
+++ b/report-app/src/app/pages/report-viewer/report-viewer.scss
@@ -63,7 +63,7 @@ expansion-panel {
   padding: 0 1rem 1rem;
 }
 
-.app-details-section expansion-panel {
+.app-details-section expansion-panel, .app-details-section button {
   margin-bottom: 0.5rem;
 }
 
@@ -233,3 +233,32 @@ expansion-panel {
   padding: 0px 20px;
 }
 
+.mcp-log-entry {
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  margin: 1rem 0;
+
+  & > summary {
+    cursor: pointer;
+    font-weight: 500;
+    padding: 1rem 1.5rem;
+
+    &:hover {
+      background-color: var(--button-active-bg-color);
+    }
+  }
+
+  & .mcp-log-content {
+    padding: 0 1.5rem 1.5rem;
+
+    h5 {
+      margin-top: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+  }
+}
+
+.tool-logs-list {
+  list-style: none;
+  padding: 0;
+}

--- a/report-app/src/app/pages/report-viewer/report-viewer.ts
+++ b/report-app/src/app/pages/report-viewer/report-viewer.ts
@@ -11,6 +11,7 @@ import {
   signal,
   viewChild,
 } from '@angular/core';
+import { NgxJsonViewerModule } from 'ngx-json-viewer';
 import { BuildErrorType } from '../../../../../runner/builder/builder-types';
 import {
   AssessmentResult,
@@ -55,6 +56,7 @@ import { ProviderLabel } from '../../shared/provider-label';
     ExpansionPanel,
     ExpansionPanelHeader,
     ProviderLabel,
+    NgxJsonViewerModule,
   ],
   templateUrl: './report-viewer.html',
   styleUrls: ['./report-viewer.scss'],

--- a/runner/codegen/gemini-cli/gemini-cli-runner.ts
+++ b/runner/codegen/gemini-cli/gemini-cli-runner.ts
@@ -89,7 +89,7 @@ export class GeminiCliRunner implements LlmRunner {
       });
     }
 
-    return { files, reasoning };
+    return { files, reasoning, toolLogs: [] };
   }
 
   generateText(): Promise<LlmGenerateTextResponse> {

--- a/runner/codegen/llm-runner.ts
+++ b/runner/codegen/llm-runner.ts
@@ -148,7 +148,7 @@ interface BaseLlmGenerateResponse {
   /** Reasoning messages from the LLM. */
   reasoning: string;
   /** Tool requests and responses. */
-  toolLogs: ToolLogEntry[];
+  toolLogs?: ToolLogEntry[];
 }
 
 /** File generation response from the LLM. */

--- a/runner/codegen/llm-runner.ts
+++ b/runner/codegen/llm-runner.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { LlmResponseFile, Usage } from '../shared-interfaces.js';
+import { LlmResponseFile, ToolLogEntry, Usage } from '../shared-interfaces.js';
 import { UserFacingError } from '../utils/errors.js';
 
 export function assertValidModelName(value: string, availableModels: string[]) {
@@ -141,22 +141,24 @@ export interface LlmConstrainedOutputGenerateResponse<
   reasoning: string;
 }
 
-/** File generation response from the LLM. */
-export interface LlmGenerateFilesResponse {
-  files: LlmResponseFile[];
+/** LLM response. */
+interface BaseLlmGenerateResponse {
   /** Token usage data, if available. */
   usage?: Partial<Usage>;
   /** Reasoning messages from the LLM. */
   reasoning: string;
+  /** Tool requests and responses. */
+  toolLogs: ToolLogEntry[];
+}
+
+/** File generation response from the LLM. */
+export interface LlmGenerateFilesResponse extends BaseLlmGenerateResponse {
+  files: LlmResponseFile[];
 }
 
 /** Text response from the LLM. */
-export interface LlmGenerateTextResponse {
+export interface LlmGenerateTextResponse extends BaseLlmGenerateResponse {
   text: string;
-  /** Token usage data, if available. */
-  usage?: Partial<Usage>;
-  /** Reasoning messages from the LLM. */
-  reasoning: string;
 }
 
 /** Schema for the LLM server options. */

--- a/runner/orchestration/codegen.ts
+++ b/runner/orchestration/codegen.ts
@@ -3,6 +3,7 @@ import {
   LlmResponse,
   LlmResponseFile,
   RootPromptDefinition,
+  ToolLogEntry,
   Usage,
 } from '../shared-interfaces.js';
 import {
@@ -49,6 +50,7 @@ export async function generateCodeWithAI(
   let usage: Usage;
   let success: boolean;
   let reasoning: string;
+  let toolLogs: ToolLogEntry[];
 
   const contextMessageData = prepareContextFilesMessage(contextFiles);
   const messages: PromptDataMessage[] | undefined = contextMessageData
@@ -72,6 +74,7 @@ export async function generateCodeWithAI(
       totalTokens: response.usage?.totalTokens ?? 0,
     };
     reasoning = response.reasoning;
+    toolLogs = response.toolLogs ?? [];
 
     progress.log(
       promptDef,
@@ -100,6 +103,7 @@ export async function generateCodeWithAI(
     usage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
     success = false;
     reasoning = '';
+    toolLogs = [];
     errors.push(error + '');
     progress.log(
       promptDef,
@@ -117,6 +121,7 @@ export async function generateCodeWithAI(
     errors,
     usage,
     reasoning,
+    toolLogs,
   } satisfies LlmResponse;
 }
 

--- a/runner/orchestration/generate.ts
+++ b/runner/orchestration/generate.ts
@@ -350,7 +350,7 @@ async function startEvaluationTask(
       progress
     );
 
-    const toolLogs = initialResponse.toolLogs;
+    const toolLogs = initialResponse.toolLogs ?? [];
 
     if (!initialResponse) {
       progress.log(
@@ -688,7 +688,7 @@ async function installChrome(): Promise<void> {
 
   try {
     await chromeInstallPromise;
-  } catch {}
+  } catch {} // Ignore errors here, as it might be already installed.
 }
 
 /**

--- a/runner/shared-interfaces.ts
+++ b/runner/shared-interfaces.ts
@@ -105,6 +105,8 @@ export interface LlmResponse {
   usage: Usage;
   /** Reasoning messages from the LLM for generating this response. */
   reasoning: string;
+  /** Tool requests logs (e.g. MCP requests and responses). */
+  toolLogs: ToolLogEntry[];
 }
 
 /** Error response from an LLM API. */
@@ -367,6 +369,24 @@ export interface RunDetails {
 }
 
 /**
+ * Logs for a single tool request and response (e.g. an MCP tool).
+ *
+ * Fields are coming from GenerateRequestSchema.
+ */
+export interface ToolLogEntry {
+  request: {
+    name: string;
+    ref?: string | undefined;
+    input?: unknown;
+  };
+  response: {
+    name: string;
+    output?: unknown;
+    ref?: string | undefined;
+  };
+}
+
+/**
  * Encapsulates all results and details for the assessment of a single prompt.
  * This includes the original prompt definition, the final generated code,
  * build status, code quality score, number of repair attempts, and details of each attempt.
@@ -388,6 +408,8 @@ export interface AssessmentResult {
   userJourneys?: UserJourneysResult;
   /** The number of repair attempts made after the axe initial failures. */
   axeRepairAttempts: number;
+  /** Tool requests logs (e.g. MCP requests and responses). */
+  toolLogs: ToolLogEntry[];
 }
 
 /**

--- a/runner/shared-interfaces.ts
+++ b/runner/shared-interfaces.ts
@@ -106,7 +106,7 @@ export interface LlmResponse {
   /** Reasoning messages from the LLM for generating this response. */
   reasoning: string;
   /** Tool requests logs (e.g. MCP requests and responses). */
-  toolLogs: ToolLogEntry[];
+  toolLogs?: ToolLogEntry[];
 }
 
 /** Error response from an LLM API. */
@@ -409,7 +409,7 @@ export interface AssessmentResult {
   /** The number of repair attempts made after the axe initial failures. */
   axeRepairAttempts: number;
   /** Tool requests logs (e.g. MCP requests and responses). */
-  toolLogs: ToolLogEntry[];
+  toolLogs?: ToolLogEntry[];
 }
 
 /**


### PR DESCRIPTION
This adds a subsection to the debug section that displays tool logs (specifically, MCP tools) - request and response pairs. It adds `ngx-json-viewer` dependency for a nicer display of these JSONs.

<img width="2274" height="1498" alt="image" src="https://github.com/user-attachments/assets/ab593efe-963b-401b-8bc6-4caa718a5672" />
