### PR TITLE
fix: Incorrect Security Stats when using `--enableAutoCsp`

### DIFF
--- a/runner/ratings/stats.ts
+++ b/runner/ratings/stats.ts
@@ -86,10 +86,23 @@ export function calculateBuildAndCheckStats(
       }
     }
     securityStats ??= { appsWithErrors: 0, appsWithoutErrors: 0 };
-    const numCspViolations = (result.build.cspViolations || []).length;
+    const { numCspViolations, numTrustedTypesViolations } = (
+      result.build.cspViolations || []
+    ).reduce(
+      (acc, v) => {
+        if (v['blocked-uri'] === 'trusted-types-sink') {
+          acc.numTrustedTypesViolations++;
+        } else {
+          acc.numCspViolations++;
+        }
+        return acc;
+      },
+      { numCspViolations: 0, numTrustedTypesViolations: 0 }
+    );
+
     const hasSafetyViolations =
       (result.build.safetyWebReportJson?.[0]?.violations?.length ?? 0) > 0;
-
+    // TODO: Consider numTrustedTypesViolations once we update autoCsp and re-enable the rating.
     if (hasSafetyViolations || numCspViolations > 0) {
       securityStats.appsWithErrors++;
     } else {


### PR DESCRIPTION
In the reports webapp, we see a large number of "Security" findings in the runs if we use the `--enableAutoCsp` flag

<img width="464" height="110" alt="image" src="https://github.com/user-attachments/assets/60f44cba-fdf2-49fc-9280-ad06e47796f0" />

This is because in stats.ts, we are counting the number of CSP reports that are seen during the WebDriver session with autoCSP enabled. Even though we are not tracking Trusted Types violations at this moment, we end up counting Trusted Types violations as a part of security findings. This is currently problematic because the version of the `strict-csp` HTML transformation library we use generates a lot of false positive Trusted Types violations as a part of the loader script.

We will not count any Trusted Types violations as security findings until `strict-csp` is updated to no longer produce false positives. This currently aligns with the name of the variable in the checking-- `numCspViolations` should count only CSP violations. To make this future-proof, I've separated out CSP and TT findings in `stats.ts`-- and we can start counting `numTrustedTypesViolations` in the future!

Thanks to @devversion for noticing this!