### PR TITLE
fix: improve stability by properly limiting worker instances

### DIFF
--- a/runner/orchestration/build-repair.ts
+++ b/runner/orchestration/build-repair.ts
@@ -71,6 +71,7 @@ export async function repairAndBuild(
     rootPromptDef,
     directory,
     workerConcurrencyQueue,
+    abortSignal,
     attempts,
     progress
   );
@@ -89,6 +90,7 @@ async function handleRepairResponse(
   rootPromptDef: RootPromptDefinition,
   directory: string,
   workerConcurrencyQueue: PQueue,
+  abortSignal: AbortSignal,
   attempts: number,
   progress: ProgressLogger
 ) {
@@ -107,9 +109,15 @@ async function handleRepairResponse(
   mergeRepairFiles(repairResponse.outputFiles, finalOutputFiles);
   writeResponseFiles(directory, finalOutputFiles, env, rootPromptDef.name);
 
-  const buildResult = await workerConcurrencyQueue.add(
-    () => runBuild(evalID, gateway, directory, env, rootPromptDef, progress),
-    { throwOnTimeout: true }
+  const buildResult = await runBuild(
+    evalID,
+    gateway,
+    directory,
+    env,
+    rootPromptDef,
+    abortSignal,
+    workerConcurrencyQueue,
+    progress
   );
 
   return {

--- a/runner/orchestration/build-serve-loop.ts
+++ b/runner/orchestration/build-serve-loop.ts
@@ -5,9 +5,7 @@ import { Environment } from '../configuration/environment.js';
 import {
   AttemptDetails,
   LlmContextFile,
-  LlmResponseFile,
   RootPromptDefinition,
-  Usage,
 } from '../shared-interfaces.js';
 import { DEFAULT_MAX_REPAIR_ATTEMPTS } from '../configuration/constants.js';
 import { ProgressLogger } from '../progress/progress-logger.js';
@@ -59,9 +57,15 @@ export async function attemptBuild(
   const finalOutputFiles = initialResponse.files.map((file) => ({
     ...file,
   }));
-  const initialBuildResult = await workerConcurrencyQueue.add(
-    () => runBuild(evalID, gateway, directory, env, rootPromptDef, progress),
-    { throwOnTimeout: true }
+  const initialBuildResult = await runBuild(
+    evalID,
+    gateway,
+    directory,
+    env,
+    rootPromptDef,
+    abortSignal,
+    workerConcurrencyQueue,
+    progress
   );
   let repairAttempts = 0;
   const maxRepairAttempts = gateway.shouldRetryFailedBuilds(evalID)
@@ -122,6 +126,8 @@ export async function attemptBuild(
     directory,
     env,
     rootPromptDef,
+    workerConcurrencyQueue,
+    abortSignal,
     progress,
     skipScreenshots,
     skipAxeTesting,
@@ -176,6 +182,8 @@ export async function attemptBuild(
       directory,
       env,
       rootPromptDef,
+      workerConcurrencyQueue,
+      abortSignal,
       progress,
       skipScreenshots,
       skipAxeTesting,

--- a/runner/orchestration/build-worker.ts
+++ b/runner/orchestration/build-worker.ts
@@ -6,6 +6,7 @@ import { Environment } from '../configuration/environment.js';
 import { ProgressLogger } from '../progress/progress-logger.js';
 import { RootPromptDefinition } from '../shared-interfaces.js';
 import { EvalID, Gateway } from './gateway.js';
+import PQueue from 'p-queue';
 
 /** Attempts to build the code. */
 export async function runBuild(
@@ -14,6 +15,8 @@ export async function runBuild(
   appDirectoryPath: string,
   env: Environment,
   rootPromptDef: RootPromptDefinition,
+  abortSignal: AbortSignal,
+  workerConcurrencyQueue: PQueue,
   progress: ProgressLogger
 ): Promise<BuildResult> {
   progress.log(rootPromptDef, 'build', `Building the app`);
@@ -24,6 +27,8 @@ export async function runBuild(
       env,
       appDirectoryPath,
       rootPromptDef,
+      workerConcurrencyQueue,
+      abortSignal,
       progress
     );
     if (result.status === BuildResultStatus.SUCCESS) {

--- a/runner/orchestration/gateway.ts
+++ b/runner/orchestration/gateway.ts
@@ -1,3 +1,4 @@
+import PQueue from 'p-queue';
 import { LlmGenerateFilesContext } from '../codegen/llm-runner.js';
 import { Environment } from '../configuration/environment.js';
 import { ProgressLogger } from '../progress/progress-logger.js';
@@ -41,6 +42,8 @@ export interface Gateway<Env extends Environment> {
     env: Env,
     appDirectoryPath: string,
     rootPromptDef: RootPromptDefinition,
+    workerConcurrencyQueue: PQueue,
+    abortSignal: AbortSignal,
     progress: ProgressLogger
   ): Promise<BuildResult>;
 


### PR DESCRIPTION
With the remote environment refactorings, we no longer did guard the serve testing logic via the `workerConcurrencyQueue`. This commit makes sure this is still the case + properly passes around abort signals.