### PR TITLE
feat(runner): add support for running and repairing tests

### DIFF
--- a/docs/environment-reference.md
+++ b/docs/environment-reference.md
@@ -179,3 +179,8 @@ Defaults to `<package manager> run build`.
 
 Command used to start a local dev server as a part of the evaluation.
 Defaults to `<package manager> run start --port 0`.
+
+### `testCommand`
+
+Command used to run tests against the generated code. If this property is not provided, tests will not be run. The command should exit with code 0 on success and a non-zero exit code on failure. The output from the command (both `stdout` and `stderr`) is captured and used for repair attempts if the tests fail. The test command will time out after 4 minutes.
+

--- a/report-app/src/app/pages/report-viewer/report-viewer.html
+++ b/report-app/src/app/pages/report-viewer/report-viewer.html
@@ -73,6 +73,20 @@
             <stacked-bar-chart [data]="buildsAsGraphData(overview.stats.builds)" [compact]="true" />
           </div>
         </div>
+        @if (overview.stats.tests) {
+          <div class="chart-container test-results-details">
+            <h3 class="chart-title">
+              <span class="material-symbols-outlined"> quiz </span>
+              <span>Tests</span>
+            </h3>
+            <div class="summary-card-item">
+              <stacked-bar-chart
+                [data]="testsAsGraphData(overview.stats.tests)"
+                [compact]="true"
+              />
+            </div>
+          </div>
+        }
         @if (overview.stats.runtime) {
           <div class="chart-container">
             <h3 class="chart-title">
@@ -276,8 +290,18 @@
                   <span class="status-badge error">Initial build failed</span>
                 }
 
-                @if (hasBuildFailureDuringA11yRepair(result)) {
+                @if (hasBuildFailureDuringTestRepair(result)) {
                   <span class="status-badge error">Build failed after a11y repair</span>
+                }
+                <!-- Test status badges -->
+                @if (finalAttempt.testResult) {
+                  @if (finalAttempt.testResult.passed) {
+                    @if ((result.testRepairAttempts || 0) > 0) {
+                      <span class="status-badge warning">Tests passed after repair</span>
+                    }
+                  } @else {
+                    <span class="status-badge error">Tests failed</span>
+                  }
                 }
               </div>
             </div>
@@ -350,12 +374,36 @@
                 </div>
               </div>
 
+              @if (result.testResult) {
+                <div class="app-details-section">
+                  <h4>Test Results</h4>
+                  <div class="test-summary">
+                    @if (result.testResult.passed) {
+                      <span class="status-text success">✔ Tests passed</span>
+                      @if ((result.testRepairAttempts || 0) > 0) {
+                        <span class="status-text">&nbsp;after {{ result.testRepairAttempts }} repair attempt(s)</span>
+                      }
+                    } @else {
+                      <span class="status-text error">✘ Tests failed</span>
+                    }
+                  </div>
+                  
+                  @if (result.testResult.output && !result.testResult.passed) {
+                    <details class="test-output-button">
+                      <summary class="neutral-button">See Test Output</summary>
+                      <pre class="callout neutral code">{{ result.testResult.output }}</pre>
+                    </details>
+                  }
+                </div>
+              }
+
               <div class="app-details-section">
                 <h4>Additional info</h4>
                 @for (attempt of result.attemptDetails; track attempt) {
                   @let isBuilt = attempt.buildResult.status === 'success';
                   @let axeViolations = attempt.serveTestingResult?.axeViolations;
                   @let hasAxeViolations = axeViolations && axeViolations.length > 0;
+                  @let testsFailed = attempt.testResult?.passed === false;
 
                   <expansion-panel #expansionPanel>
                     <expansion-panel-header>
@@ -378,6 +426,15 @@
                           [class.error]="hasAxeViolations"
                           [class.success]="!hasAxeViolations"
                           >A11y</span
+                        >
+                      }
+
+                      @if (attempt.testResult) {
+                        <span
+                          class="status-badge"
+                          [class.error]="!attempt.testResult.passed"
+                          [class.success]="attempt.testResult.passed"
+                          >Tests</span
                         >
                       }
                     </expansion-panel-header>
@@ -414,6 +471,11 @@
                             }
                           </ul>
                         </pre>
+                      }
+
+                      @if (testsFailed) {
+                        <h4>Failed Tests</h4>
+                        <pre class="callout neutral code">{{ attempt.testResult?.output }}</pre>
                       }
 
                       <h4>Generated Code</h4>

--- a/report-app/src/app/pages/report-viewer/report-viewer.ts
+++ b/report-app/src/app/pages/report-viewer/report-viewer.ts
@@ -21,6 +21,7 @@ import {
   LlmResponseFile,
   RunInfo,
   RunSummaryBuilds,
+  RunSummaryTests,
   RuntimeStats,
   ScoreBucket,
   SkippedIndividualAssessment,
@@ -265,6 +266,31 @@ export class ReportViewer {
     ];
   }
 
+  protected testsAsGraphData(tests: RunSummaryTests): StackedBarChartData {
+    return [
+      {
+        label: 'Passed',
+        color: ScoreCssVariable.excellent,
+        value: tests.successfulInitialTests,
+      },
+      {
+        label: 'Passed after repair',
+        color: ScoreCssVariable.great,
+        value: tests.successfulTestsAfterRepair,
+      },
+      {
+        label: 'Failed',
+        color: ScoreCssVariable.poor,
+        value: tests.failedTests,
+      },
+      {
+        label: 'No tests run',
+        color: ScoreCssVariable.neutral,
+        value: tests.noTestsRun,
+      },
+    ];
+  }
+
   protected checksAsGraphData(buckets: ScoreBucket[]): StackedBarChartData {
     return buckets.map(b => ({
       label: b.nameWithLabels,
@@ -400,7 +426,7 @@ export class ReportViewer {
     return `wcs run --prompt=${result.promptDef.name} --env=<path to ${report.details.summary.environmentId} config>`;
   }
 
-  protected hasBuildFailureDuringA11yRepair(result: AssessmentResult): boolean {
-    return result.attemptDetails.some(attempt => attempt.buildFailedDuringA11yRepair);
+  protected hasBuildFailureDuringTestRepair(result: AssessmentResult): boolean {
+    return result.attemptDetails.some(attempt => attempt.buildFailedDuringTestRepair);
   }
 }

--- a/runner/configuration/constants.ts
+++ b/runner/configuration/constants.ts
@@ -25,7 +25,13 @@ export const LLM_OUTPUT_DIR = join(rootDir, 'llm-output');
  * providing the build output and the code that causes the problem.
  */
 // Note: When updating, also adjust the default description in `README.md`.
-export const DEFAULT_MAX_REPAIR_ATTEMPTS = 1;
+export const DEFAULT_MAX_BUILD_REPAIR_ATTEMPTS = 1;
+
+/**
+ * Number of times we'll try to ask LLM to repair test failures
+ * E.g. Axe violations, or test command failures
+ */
+export const DEFAULT_MAX_TEST_REPAIR_ATTEMPTS = 1;
 
 /** Name of the folder where we store all generated reports */
 export const REPORTS_ROOT_DIR = join(rootDir, 'reports');

--- a/runner/configuration/environment-config.ts
+++ b/runner/configuration/environment-config.ts
@@ -73,11 +73,6 @@ export const environmentConfigSchema = z.object({
 export type EnvironmentConfig = z.infer<typeof environmentConfigSchema> &
   Partial<LocalExecutorConfig>;
 
-/** Package managers that are currently supported. */
-export function getPossiblePackageManagers() {
-  return ['npm', 'pnpm', 'yarn'] as const;
-}
-
 /** Asserts that the specified data is a valid environment config. */
 export function assertIsEnvironmentConfig(value: unknown): asserts value is EnvironmentConfig {
   const validationResult = environmentConfigSchema

--- a/runner/configuration/package-managers.ts
+++ b/runner/configuration/package-managers.ts
@@ -1,0 +1,4 @@
+/** Package managers that are currently supported. */
+export function getPossiblePackageManagers() {
+  return ['npm', 'pnpm', 'yarn'] as const;
+}

--- a/runner/eval-cli.ts
+++ b/runner/eval-cli.ts
@@ -3,7 +3,8 @@ import chalk from 'chalk';
 import {
   BUILT_IN_ENVIRONMENTS,
   DEFAULT_AUTORATER_MODEL_NAME,
-  DEFAULT_MAX_REPAIR_ATTEMPTS,
+  DEFAULT_MAX_BUILD_REPAIR_ATTEMPTS,
+  DEFAULT_MAX_TEST_REPAIR_ATTEMPTS,
   DEFAULT_MODEL_NAME,
 } from './configuration/constants.js';
 import {generateCodeAndAssess} from './orchestration/generate.js';
@@ -37,9 +38,9 @@ interface Options {
   enableUserJourneyTesting?: boolean;
   enableAutoCsp?: boolean;
   autoraterModel?: string;
-  a11yRepairAttempts?: number;
   logging?: 'text-only' | 'dynamic';
   skipLighthouse?: boolean;
+  maxTestRepairAttempts?: number;
   maxBuildRepairAttempts?: number;
 }
 
@@ -151,11 +152,6 @@ function builder(argv: Argv): Argv<Options> {
         default: DEFAULT_AUTORATER_MODEL_NAME,
         description: 'Model to use when automatically rating generated code',
       })
-      .option('a11y-repair-attempts', {
-        type: 'number',
-        default: 0,
-        description: 'Number of repair attempts for discovered a11y violations',
-      })
       .option('skip-lighthouse', {
         type: 'boolean',
         default: false,
@@ -163,8 +159,14 @@ function builder(argv: Argv): Argv<Options> {
       })
       .option('max-build-repair-attempts', {
         type: 'number',
-        default: DEFAULT_MAX_REPAIR_ATTEMPTS,
+        default: DEFAULT_MAX_BUILD_REPAIR_ATTEMPTS,
         description: 'Number of repair attempts when build errors are discovered',
+      })
+      .option('max-test-repair-attempts', {
+        type: 'number',
+        default: DEFAULT_MAX_TEST_REPAIR_ATTEMPTS,
+        description:
+          'Number of repair attempts for discovered test failures (including a11y violations and ones from testCommand)',
       })
       .strict()
       .version(false)
@@ -209,9 +211,9 @@ async function handler(cliArgs: Arguments<Options>): Promise<void> {
       logging: cliArgs.logging,
       autoraterModel: cliArgs.autoraterModel,
       skipAiSummary: cliArgs.skipAiSummary,
-      a11yRepairAttempts: cliArgs.a11yRepairAttempts,
       skipLighthouse: cliArgs.skipLighthouse,
       maxBuildRepairAttempts: cliArgs.maxBuildRepairAttempts,
+      maxTestRepairAttempts: cliArgs.maxTestRepairAttempts,
     });
 
     logReportToConsole(runInfo);

--- a/runner/orchestration/executors/executor.ts
+++ b/runner/orchestration/executors/executor.ts
@@ -6,6 +6,7 @@ import {
   LlmResponse,
   LlmResponseFile,
   RootPromptDefinition,
+  TestExecutionResult,
 } from '../../shared-interfaces.js';
 import {BuildResult} from '../../workers/builder/builder-types.js';
 import z from 'zod';
@@ -71,6 +72,19 @@ export const executorSchema = z.object({
         .describe('Call this function while the server is running'),
     ]),
     z.promise(z.custom<ServeTestingResult>()),
+  ),
+  executeProjectTests: z.function(
+    z.tuple([
+      z.custom<EvalID>().describe('ID of the eval'),
+      z.string().describe('Path to the application directory'),
+      z.custom<RootPromptDefinition>().describe('Root prompt definition'),
+      z
+        .custom<WorkerQueueType>()
+        .describe('Worker concurrency queue. Use this for limiting local workers.'),
+      z.custom<AbortSignal>().describe('Abort Signal to fire when tests should be canceled.'),
+      z.custom<ProgressLogger>().describe('Progress logger'),
+    ]),
+    z.promise(z.custom<TestExecutionResult>().nullable()),
   ),
   finalizeEval: z.function(
     z.tuple([z.custom<EvalID>().describe('ID of the eval')]),

--- a/runner/orchestration/executors/local-executor-config.ts
+++ b/runner/orchestration/executors/local-executor-config.ts
@@ -1,6 +1,6 @@
 import z from 'zod';
 import {mcpServerOptionsSchema} from '../../codegen/llm-runner.js';
-import {getPossiblePackageManagers} from '../../configuration/environment-config.js';
+import {getPossiblePackageManagers} from '../../configuration/package-managers.js';
 
 export const localExecutorConfigSchema = z.strictObject({
   /** MCP servers that can be started for this environment. */
@@ -24,6 +24,10 @@ export const localExecutorConfigSchema = z.strictObject({
    * Defaults to `<package manager> run start --port 0`.
    */
   serveCommand: z.string().optional(),
+  /**
+   * Optional command for executing project tests.
+   */
+  testCommand: z.string().optional(),
   /**
    * Whether to skip installing dependencies when running evals in the environment.
    * Useful if you're managing dependencies yourself.

--- a/runner/orchestration/repair.ts
+++ b/runner/orchestration/repair.ts
@@ -1,3 +1,4 @@
+import {Environment} from '../configuration/environment.js';
 import PQueue from 'p-queue';
 import {
   AttemptDetails,
@@ -6,12 +7,11 @@ import {
   LlmResponseFile,
   RootPromptDefinition,
 } from '../shared-interfaces.js';
-import {Environment} from '../configuration/environment.js';
-import {repairCodeWithAI} from './codegen.js';
-import {writeResponseFiles} from './file-system.js';
 import {runBuild} from './build-worker.js';
 import {ProgressLogger} from '../progress/progress-logger.js';
-import {EvalID, Executor} from './executors/executor.js';
+import {EvalID} from './executors/executor.js';
+import {repairCodeWithAI} from './codegen.js';
+import {writeResponseFiles} from './file-system.js';
 
 /**
  * Calls the LLM to repair code, handles the response, and attempts to build the project again.
@@ -22,12 +22,11 @@ import {EvalID, Executor} from './executors/executor.js';
  * @param directory The working directory.
  * @param finalOutputFiles The list of output files to be modified.
  * @param errorMessage The error message from the failed build.
- * @param errorContext Additional context for the error.
+ * @param errors Additional context for the error.
  * @param contextFiles A list of context files for the LLM.
  * @param abortSignal An AbortSignal to cancel the operation.
  * @param workerConcurrencyQueue The queue for managing worker concurrency.
  * @param attempts The current attempt number.
- * @param repairType The type of repair being performed.
  * @returns A promise that resolves to the new BuildResult.
  */
 export async function repairAndBuild(
@@ -37,13 +36,13 @@ export async function repairAndBuild(
   rootPromptDef: RootPromptDefinition,
   directory: string,
   previousAttemptFiles: LlmResponseFile[],
-  errorMessage: string,
-  errorContext: string,
+  errors: Array<{errorContext: string; errorMessage: string}>,
   contextFiles: LlmContextFile[],
   abortSignal: AbortSignal,
   workerConcurrencyQueue: PQueue,
   attempts: number,
   progress: ProgressLogger,
+  repairType: 'build' | 'test',
 ): Promise<AttemptDetails> {
   const repairResponse = await repairCodeWithAI(
     evalID,
@@ -52,11 +51,11 @@ export async function repairAndBuild(
     rootPromptDef,
     directory,
     previousAttemptFiles,
-    errorMessage,
-    errorContext,
+    errors,
     contextFiles,
     abortSignal,
     progress,
+    repairType,
   );
 
   return await handleRepairResponse(
@@ -74,6 +73,27 @@ export async function repairAndBuild(
 }
 
 /**
+ * Merges a set of new or updated files from a repair attempt into the
+ * current set of files.
+ * @param repairOutputFiles The array of new or updated files to merge.
+ * @param finalFiles The array of files to be updated.
+ */
+function mergeRepairFiles(repairOutputFiles: LlmResponseFile[], finalFiles: LlmResponseFile[]) {
+  // Merge the repair response into the original files. Otherwise we may end up dropping
+  // files that were valid in the initial response and the LLM decided not to touch, because
+  // they're still valid.
+  for (const file of repairOutputFiles) {
+    const existingFile = finalFiles.find(f => f.filePath === file.filePath);
+
+    if (existingFile) {
+      existingFile.code = file.code;
+    } else {
+      finalFiles.push(file);
+    }
+  }
+}
+
+/**
  * Processes an LLM repair response by merging the suggested file changes,
  * writing them to disk, rebuilding the application, and logging the outcome.
  */
@@ -88,7 +108,7 @@ async function handleRepairResponse(
   abortSignal: AbortSignal,
   attempts: number,
   progress: ProgressLogger,
-) {
+): Promise<AttemptDetails> {
   if (!repairResponse.success) {
     progress.log(
       rootPromptDef,
@@ -99,7 +119,6 @@ async function handleRepairResponse(
     // Stop trying to repair if AI can't suggest a fix (API request fails)
     throw new Error(`Repair request failed: ${repairResponse.errors.join('\n')}`);
   }
-
   // Clone the previous files because `mergeRepairFiles` mutates the attempt files.
   // We don't want to change files of a previous attempt.
   const newAttemptFiles = previousAttemptFiles.map(f => ({...f}));
@@ -125,25 +144,4 @@ async function handleRepairResponse(
     serveTestingResult: null,
     attempt: attempts,
   };
-}
-
-/**
- * Merges a set of new or updated files from a repair attempt into the
- * current set of files.
- * @param repairOutputFiles The array of new or updated files to merge.
- * @param finalFiles The array of files to be updated.
- */
-function mergeRepairFiles(repairOutputFiles: LlmResponseFile[], finalFiles: LlmResponseFile[]) {
-  // Merge the repair response into the original files. Otherwise we may end up dropping
-  // files that were valid in the initial response and the LLM decided not to touch, because
-  // they're still valid.
-  for (const file of repairOutputFiles) {
-    const existingFile = finalFiles.find(f => f.filePath === file.filePath);
-
-    if (existingFile) {
-      existingFile.code = file.code;
-    } else {
-      finalFiles.push(file);
-    }
-  }
 }

--- a/runner/orchestration/test-worker.ts
+++ b/runner/orchestration/test-worker.ts
@@ -1,0 +1,42 @@
+import PQueue from 'p-queue';
+import {RootPromptDefinition, TestExecutionResult} from '../shared-interfaces.js';
+import {ProgressLogger} from '../progress/progress-logger.js';
+import {Environment} from '../configuration/environment.js';
+import {EvalID} from './executors/executor.js';
+
+export async function runTest(
+  env: Environment,
+  evalID: EvalID,
+  appDirectoryPath: string,
+  rootPromptDef: RootPromptDefinition,
+  abortSignal: AbortSignal,
+  workerConcurrencyQueue: PQueue,
+  progress: ProgressLogger,
+): Promise<TestExecutionResult | null> {
+  progress.log(rootPromptDef, 'test', `Running tests`);
+
+  try {
+    const result = await env.executor.executeProjectTests(
+      evalID,
+      appDirectoryPath,
+      rootPromptDef,
+      workerConcurrencyQueue,
+      abortSignal,
+      progress,
+    );
+    if (result === null) {
+      return result;
+    }
+
+    if (result.passed) {
+      progress.log(rootPromptDef, 'success', 'Tests have passed');
+    } else {
+      progress.log(rootPromptDef, 'error', 'Tests have failed');
+    }
+
+    return result;
+  } catch (err) {
+    progress.log(rootPromptDef, 'error', `Error when executing tests`, err + '');
+    throw err;
+  }
+}

--- a/runner/progress/dynamic-progress-logger.ts
+++ b/runner/progress/dynamic-progress-logger.ts
@@ -148,6 +148,7 @@ export class DynamicProgressLogger implements ProgressLogger {
     switch (type) {
       case 'success':
       case 'serve-testing':
+      case 'test':
       case 'build':
         return chalk.green;
       case 'error':

--- a/runner/progress/progress-logger.ts
+++ b/runner/progress/progress-logger.ts
@@ -2,7 +2,14 @@ import {greenCheckmark, redX} from '../reporting/format.js';
 import {AssessmentResult, RootPromptDefinition} from '../shared-interfaces.js';
 
 /** Possible progress event types. */
-export type ProgressType = 'codegen' | 'build' | 'serve-testing' | 'success' | 'error' | 'eval';
+export type ProgressType =
+  | 'codegen'
+  | 'build'
+  | 'test'
+  | 'serve-testing'
+  | 'success'
+  | 'error'
+  | 'eval';
 
 /** Maps a ProgressType to an icon that can represent it. */
 export function progressTypeToIcon(type: ProgressType): string {
@@ -12,6 +19,8 @@ export function progressTypeToIcon(type: ProgressType): string {
       return '🤖';
     case 'build':
       return '🔨';
+    case 'test':
+      return '🧪';
     case 'serve-testing':
       return '🌊';
     case 'success':

--- a/runner/ratings/built-in-ratings/successful-tests-rating.ts
+++ b/runner/ratings/built-in-ratings/successful-tests-rating.ts
@@ -1,0 +1,28 @@
+import {PerBuildRating, RatingKind, RatingCategory, RatingState} from '../rating-types.js';
+
+/** Rating which verifies that unit tests pass successfully. */
+export const successfulTestsRating: PerBuildRating = {
+  name: 'Tests pass successfully',
+  description: 'Ensures tests run and pass without errors.',
+  id: 'common-successful-tests',
+  kind: RatingKind.PER_BUILD,
+  category: RatingCategory.MEDIUM_IMPACT,
+  scoreReduction: '30%',
+  // Reduce the amount of points in case we've had test repair attempts.
+  rate: ({testResult, testRepairAttempts}) => {
+    // If no test results are available, skip this rating
+    if (!testResult) {
+      return {
+        state: RatingState.SKIPPED,
+        message: 'Unit testing not configured.',
+      };
+    }
+
+    return {
+      state: RatingState.EXECUTED,
+      coefficient: testResult.passed
+        ? 1 / ((testRepairAttempts || 0) + 1) // Reduce score based on repair attempts
+        : 0, // No points if tests failed
+    };
+  },
+};

--- a/runner/ratings/rate-code.ts
+++ b/runner/ratings/rate-code.ts
@@ -8,6 +8,7 @@ import {
   IndividualAssessmentState,
   PromptDefinition,
   AssessmentCategory,
+  TestExecutionResult,
 } from '../shared-interfaces.js';
 import {
   RatingState,
@@ -56,6 +57,8 @@ export async function rateGeneratedCode(
   abortSignal: AbortSignal,
   progress: ProgressLogger,
   autoraterModel: string,
+  testResult: TestExecutionResult | null,
+  testRepairAttempts: number,
 ): Promise<CodeAssessmentScore> {
   let categorizedFiles: CategorizedFiles | null = null;
   let totalPoints = 0;
@@ -93,6 +96,8 @@ export async function rateGeneratedCode(
           buildResult,
           serveTestingResult,
           repairAttempts,
+          testResult,
+          testRepairAttempts,
           outputFiles.length,
           axeRepairAttempts,
           ratingsResult,
@@ -173,6 +178,8 @@ function runPerBuildRating(
   buildResult: BuildResult,
   serveResult: ServeTestingResult | null,
   repairAttempts: number,
+  testResult: TestExecutionResult | null,
+  testRepairAttempts: number,
   generatedFileCount: number,
   axeRepairAttempts: number,
   ratingsResult: RatingsResult,
@@ -184,6 +191,8 @@ function runPerBuildRating(
     generatedFileCount,
     axeRepairAttempts,
     ratingsResult,
+    testResult,
+    testRepairAttempts,
   });
 
   // If the rating was skipped (e.g., Axe test wasn't run), create a skipped assessment.

--- a/runner/ratings/rating-types.ts
+++ b/runner/ratings/rating-types.ts
@@ -5,6 +5,7 @@ import type {
   LlmResponseFile,
   PromptDefinition,
   SkippedIndividualAssessment,
+  TestExecutionResult,
   Usage,
 } from '../shared-interfaces.js';
 import {Environment} from '../configuration/environment.js';
@@ -64,6 +65,8 @@ const perBuildRatingSchema = z
           buildResult: z.custom<BuildResult>(),
           serveResult: z.custom<ServeTestingResult | null>(),
           repairAttempts: z.number(),
+          testResult: z.custom<TestExecutionResult | null>(),
+          testRepairAttempts: z.number(),
           axeRepairAttempts: z.number(),
           generatedFileCount: z.number(),
           ratingsResult: z.record(z.custom<IndividualAssessment | SkippedIndividualAssessment>()),

--- a/runner/ratings/stats.ts
+++ b/runner/ratings/stats.ts
@@ -25,6 +25,10 @@ export function calculateBuildAndCheckStats(assessments: AssessmentResult[]): Ag
   let successfulInitialBuilds = 0;
   let successfulBuildsAfterRepair = 0;
   let failedBuilds = 0;
+  let successfulInitialTests = 0;
+  let successfulTestsAfterRepair = 0;
+  let failedTests = 0;
+  let noTestsRun = 0;
   let runtimeStats: RuntimeStats | undefined;
   let accessibilityStats:
     | {
@@ -59,6 +63,20 @@ export function calculateBuildAndCheckStats(assessments: AssessmentResult[]): Ag
       }
     }
 
+    // Calculate test statistics
+    if (result.testResult) {
+      if (result.testResult.passed) {
+        if ((result.testRepairAttempts || 0) === 0) {
+          successfulInitialTests++;
+        } else {
+          successfulTestsAfterRepair++;
+        }
+      } else {
+        failedTests++;
+      }
+    } else {
+      noTestsRun++;
+    }
     if (result.finalAttempt.serveTestingResult?.runtimeErrors != undefined) {
       runtimeStats ??= {appsWithErrors: 0, appsWithoutErrors: 0};
       if (result.finalAttempt.serveTestingResult.runtimeErrors.trim() != '') {
@@ -123,6 +141,12 @@ export function calculateBuildAndCheckStats(assessments: AssessmentResult[]): Ag
       successfulBuildsAfterRepair,
       failedBuilds,
       errorDistribution: Object.keys(errorDistribution).length > 0 ? errorDistribution : undefined,
+    },
+    tests: {
+      successfulInitialTests,
+      successfulTestsAfterRepair,
+      failedTests,
+      noTestsRun,
     },
     buckets,
     runtime: runtimeStats

--- a/runner/shared-interfaces.ts
+++ b/runner/shared-interfaces.ts
@@ -27,8 +27,8 @@ export interface AssessmentConfig {
   enableAutoCsp?: boolean;
   logging?: 'text-only' | 'dynamic';
   autoraterModel?: string;
-  a11yRepairAttempts?: number;
   skipLighthouse?: boolean;
+  maxTestRepairAttempts?: number;
   maxBuildRepairAttempts?: number;
 }
 
@@ -248,8 +248,12 @@ export interface AttemptDetails {
   // Note: May not be set in older reports.
   reasoning?: string;
 
-  /** Whether the build failed during an accessibility repair attempt. */
-  buildFailedDuringA11yRepair?: boolean;
+  /** Whether the build failed during an test repair attempt (a11y or unit). */
+  buildFailedDuringTestRepair?: boolean;
+  /** Result of running tests for this attempt. */
+  testResult?: TestExecutionResult;
+  /** The number of repair attempts made for tests in this attempt. */
+  testRepairAttempts?: number;
 }
 
 /** Statistics related to the build process of the generated applications. */
@@ -262,6 +266,18 @@ export interface RunSummaryBuilds {
   failedBuilds: number;
   /** Distribution of error types for failed builds. */
   errorDistribution?: Partial<Record<BuildErrorType, number>>;
+}
+
+/** Statistics related to the test process of the generated applications. */
+export interface RunSummaryTests {
+  /** The number of applications that had tests run and all tests passed on the first attempt. */
+  successfulInitialTests: number;
+  /** The number of applications that had tests run and all tests passed after repair attempts. */
+  successfulTestsAfterRepair: number;
+  /** The number of applications that had tests run but tests failed even after repair attempts. */
+  failedTests: number;
+  /** The number of applications that did not have tests run (no test command configured). */
+  noTestsRun: number;
 }
 
 /** Buckets into which scores can be categorized. */
@@ -298,6 +314,8 @@ export interface AggregatedRunStats {
   buckets: ScoreBucket[];
   /** Runtime stats. Not present for reports that didn't request runtime error collection. */
   runtime?: RuntimeStats;
+  /** Test stats. Not present for reports that didn't run tests or older reports. */
+  tests?: RunSummaryTests;
 
   accessibility?: {
     appsWithErrors: number;
@@ -476,6 +494,10 @@ export interface AssessmentResult {
   axeRepairAttempts: number;
   /** Tool requests logs (e.g. MCP requests and responses). */
   toolLogs?: ToolLogEntry[];
+  /** Result of running unit tests. */
+  testResult: TestExecutionResult | null;
+  /** Number of repair attempts for tests. */
+  testRepairAttempts?: number;
 }
 
 /**
@@ -564,4 +586,10 @@ export interface LlmGenerateFilesRequest {
   combinedPrompt: string;
   /** Directory in which the generation will occur. */
   directory: string;
+}
+
+/** Result of running tests. */
+export interface TestExecutionResult {
+  passed: boolean;
+  output: string;
 }


### PR DESCRIPTION
This commit introduces the ability to run tests against the generated code as part of the evaluation process.

A new optional `testCommand` can be in the environment configuration. If provided, this command will be executed after a successful build.

If the tests fail, the tool will attempt to repair the code using the LLM, similar to how build failures are handled. The number of repair attempts is configurable.

The report has been updated to display the test results for each run, including whether the tests passed, failed, or passed after repair. The summary view also includes aggregated statistics about the test results.