### PR TITLE
fix: capture all files in attempts

### DIFF
--- a/runner/orchestration/build-repair.ts
+++ b/runner/orchestration/build-repair.ts
@@ -120,10 +120,12 @@ async function handleRepairResponse(
     progress
   );
 
+  // Capture attempt's full files. Copy because `finalOutputFiles` can be
+  // mutated in subsequent repair attempts.
+  const attemptFullFiles = finalOutputFiles.map((f) => ({ ...f }));
+
   return {
-    // Log the `outputFiles` from the repair response specifically, because
-    // we want a snapshot after the current API call, not the full file set.
-    outputFiles: repairResponse.outputFiles,
+    outputFiles: attemptFullFiles,
     usage: repairResponse.usage,
     reasoning: repairResponse.reasoning,
     buildResult,


### PR DESCRIPTION
Right now subsequent attempts only display the repaired files. This is good, but it makes it super hard to see the "final product" and is a bit confusing. We should go back to the original behavior where we display the full files on every displayed attempt.