### PR TITLE
fix: ensure runtime errors are always collected

### DIFF
--- a/runner/workers/serve-testing/worker-types.ts
+++ b/runner/workers/serve-testing/worker-types.ts
@@ -16,24 +16,19 @@ export interface ServeTestingWorkerMessage {
   /** Name of the app. */
   appName: string;
   /**
-   * Whether this application should be invoked via Puppeteer and
-   * runtime errors should be collected and reported.
-   */
-  collectRuntimeErrors?: boolean;
-  /**
    * Whether to take a screenshot of the application.
    */
-  takeScreenshots?: boolean;
+  takeScreenshots: boolean;
   /**
    * Whether or not to perform Axe testing of the application.
    */
-  includeAxeTesting?: boolean;
+  includeAxeTesting: boolean;
 
   /** Whether to enable the auto CSP checks. */
-  enableAutoCsp?: boolean;
+  enableAutoCsp: boolean;
 
   /** User journey browser agent task input */
-  userJourneyAgentTaskInput?: BrowserAgentTaskInput;
+  userJourneyAgentTaskInput: BrowserAgentTaskInput | undefined;
 }
 
 export interface ServeTestingResult {

--- a/runner/workers/serve-testing/worker.ts
+++ b/runner/workers/serve-testing/worker.ts
@@ -15,7 +15,6 @@ process.on('message', async (message: ServeTestingWorkerMessage) => {
   const {
     appName,
     serveUrl,
-    collectRuntimeErrors,
     enableAutoCsp,
     includeAxeTesting,
     takeScreenshots,
@@ -57,9 +56,8 @@ process.on('message', async (message: ServeTestingWorkerMessage) => {
     screenshotBase64Data = puppeteerResult.screenshotBase64Data;
     axeViolations = puppeteerResult.axeViolations;
     cspViolations = puppeteerResult.cspViolations;
-    if (collectRuntimeErrors) {
-      runtimeErrors.push(...puppeteerResult.runtimeErrors);
-    }
+
+    runtimeErrors.push(...puppeteerResult.runtimeErrors);
 
     if (userJourneyAgentTaskInput) {
       userJourneyAgentOutput = await runBrowserAgentUserJourneyTests(


### PR DESCRIPTION
As part of the remote environment refactoring & worker splitting-up, we removed the `collectRuntimeErrors` worker IPC setting as it was always hard-coded to `true`. The worker still relied on this setting and was not collecting runtime errors. This commit removes the remainings and ensures runtime error collection always happens.