### PR TITLE
fix: re-add pre-generated AI summary section

### DIFF
--- a/report-app/src/app/pages/report-viewer/report-viewer.html
+++ b/report-app/src/app/pages/report-viewer/report-viewer.html
@@ -173,17 +173,25 @@
     </expansion-panel>
 
     @if (report.details.summary.aiSummary !== undefined) {
-      <button #aiAssistButton class="fab" (click)="isAiAssistantVisible.set(true)">
-        <span class="material-symbols-outlined">smart_toy</span>
-      </button>
+      <expansion-panel size="large" class="root-section">
+        <expansion-panel-header>
+          <img src="gemini.webp" alt="Gemini Logo" height="30" width="30" />
+          AI Summary
+        </expansion-panel-header>
+        <div [innerHTML]="report.details.summary.aiSummary"></div>
+      </expansion-panel>
+    }
 
-      @defer (on interaction(aiAssistButton)) {
-        <app-ai-assistant
-          [class.hidden]="!isAiAssistantVisible()"
-          [reportGroupId]="reportGroupId()"
-          (close)="isAiAssistantVisible.set(false)"
-        />
-      }
+    <button #aiAssistButton class="fab" (click)="isAiAssistantVisible.set(true)">
+      <span class="material-symbols-outlined">smart_toy</span>
+    </button>
+
+    @defer (on interaction(aiAssistButton)) {
+      <app-ai-assistant
+        [class.hidden]="!isAiAssistantVisible()"
+        [reportGroupId]="reportGroupId()"
+        (close)="isAiAssistantVisible.set(false)"
+      />
     }
 
     @if (missingDeps().length > 0) {
@@ -274,9 +282,7 @@
                 }
 
                 @if (hasBuildFailureDuringA11yRepair(result)) {
-                  <span class="status-badge error"
-                    >Build failed after a11y repair</span
-                  >
+                  <span class="status-badge error">Build failed after a11y repair</span>
                 }
               </div>
             </div>
@@ -343,13 +349,7 @@
                     [class.warn]="totalPercent < 90 && totalPercent >= 80"
                     [class.error]="totalPercent < 80"
                   >
-                    {{ result.score.totalPoints }} / {{ result.score.maxOverallPoints }} points ({{
-                      totalPercent
-
-
-
-
-
+                    {{ result.score.totalPoints }} / {{ result.score.maxOverallPoints }} points ({{totalPercent
                     }}%)
                   </span>
                 </div>

--- a/runner/reporting/report-ai-summary.ts
+++ b/runner/reporting/report-ai-summary.ts
@@ -11,11 +11,10 @@ export async function summarizeReportWithAI(
     llm,
     `Strictly follow the instructions here.
 
-- You are an expert in LLM-based code generation evaluation and quality assessments.
 - You will receive a report of an evaluation tool that describes LLM-generated code quality. Summarize/categorize the report.
 - Quote exact build failures, or assessment checks when possible.
 - Try to keep the summary short. e.g. cut off app names to reduce output length.
-- Return aesthetically pleasing Markdown for the report. You can use inline styles for colors.
+- Do not add an overview of scores unless necessary to illustrate common failures or low-hanging fruit.
 
 **Your primary goals (two)**:
   - Make it easy to understand what common failures are,


### PR DESCRIPTION
This section got lost with the recent AI assist chat refactorings.