### PR TITLE
feat: include tools and resources in MCP server info

### DIFF
--- a/report-app/src/app/pages/report-viewer/report-viewer.html
+++ b/report-app/src/app/pages/report-viewer/report-viewer.html
@@ -219,7 +219,7 @@
         <ul>
           @for (server of details.mcp.servers; track server) {
             <li>
-              <span>
+              <div>
                 <strong>{{ server.name }}</strong
                 >:
                 <code
@@ -228,7 +228,27 @@
                     {{ arg }}
                   }
                 </code>
-              </span>
+              </div>
+              @if (server.tools && server.tools.length > 0) {
+                <div>
+                  Tools
+                  <ul>
+                    @for (tool of server.tools; track tool) {
+                      <li>{{ tool }}</li>
+                    }
+                  </ul>
+                </div>
+              }
+              @if (server.resources && server.resources.length > 0) {
+                <div>
+                  Resources
+                  <ul>
+                    @for (tool of server.resources; track tool) {
+                      <li>{{ tool }}</li>
+                    }
+                  </ul>
+                </div>
+              }
             </li>
           }
         </ul>

--- a/runner/codegen/genkit/genkit-runner.ts
+++ b/runner/codegen/genkit/genkit-runner.ts
@@ -11,6 +11,7 @@ import {
   LlmGenerateTextResponse,
   LlmGenerateTextRequestOptions,
   LlmGenerateFilesRequestOptions,
+  McpServerDetails,
 } from '../llm-runner.js';
 import {setTimeout} from 'node:timers/promises';
 import {callWithTimeout} from '../../utils/timeout.js';
@@ -193,7 +194,7 @@ export class GenkitRunner implements LlmRunner {
     }
   }
 
-  startMcpServerHost(hostName: string, servers: McpServerOptions[]): void {
+  async startMcpServerHost(hostName: string, servers: McpServerOptions[]): Promise<McpServerDetails> {
     if (this.mcpHost !== null) {
       throw new Error('MCP host is already started');
     }
@@ -210,6 +211,12 @@ export class GenkitRunner implements LlmRunner {
 
     globalLogger.startCapturingLogs();
     this.mcpHost = createMcpHost({name: hostName, mcpServers});
+    const tools = await this.mcpHost.getActiveTools(this.genkitInstance);
+    const resources = await this.mcpHost.getActiveResources(this.genkitInstance);
+    return {
+      tools: tools.map((t) => t.__action.name),
+      resources: resources.map((r) => r.__action.name),
+    };
   }
 
   flushMcpServerLogs(): string[] {

--- a/runner/codegen/llm-runner.ts
+++ b/runner/codegen/llm-runner.ts
@@ -46,8 +46,9 @@ export interface LlmRunner {
    * Optional since not all runners may support MCP.
    * @param hostName Name for the MCP host.
    * @param servers Configured servers that should be started.
+   * @returns Details about the created server.
    */
-  startMcpServerHost?(hostName: string, servers: McpServerOptions[]): void;
+  startMcpServerHost?(hostName: string, servers: McpServerOptions[]): Promise<McpServerDetails>;
 
   /** Stops tracking MCP server logs and returns the current ones. */
   flushMcpServerLogs?(): string[];
@@ -178,6 +179,12 @@ export const mcpServerOptionsSchema = z.object({
 
 /** Options used to start an MCP server. */
 export type McpServerOptions = z.infer<typeof mcpServerOptionsSchema>;
+
+/** Details about an MCP server. */
+export interface McpServerDetails {
+  tools: string[];
+  resources: string[];
+}
 
 /**
  * Type for a prompt message may be passed to LLM runner in the eval tool.

--- a/runner/orchestration/generate.ts
+++ b/runner/orchestration/generate.ts
@@ -125,14 +125,16 @@ export async function generateCodeAndAssess(options: {
     // We need Chrome to collect runtime information.
     await installChrome();
 
-    if (
-      env instanceof LocalEnvironment &&
-      options.startMcp &&
-      env.mcpServerOptions.length &&
-      env.llm.startMcpServerHost
-    ) {
-      env.llm.startMcpServerHost(`mcp-${env.clientSideFramework.id}`, env.mcpServerOptions);
-    }
+  const mcpServerDetails =
+    env instanceof LocalEnvironment &&
+    options.startMcp &&
+    env.mcpServerOptions.length &&
+    env.llm.startMcpServerHost
+      ? await env.llm.startMcpServerHost(
+          `mcp-${env.clientSideFramework.id}`,
+          env.mcpServerOptions
+        )
+      : undefined;
 
     progress.initialize(promptsToProcess.length);
 
@@ -228,7 +230,9 @@ export async function generateCodeAndAssess(options: {
               name: m.name,
               command: m.command,
               args: m.args,
-            })),
+              tools: mcpServerDetails?.tools || [],
+              resources: mcpServerDetails?.resources || [],
+          })),
             logs: env.llm.flushMcpServerLogs().join('\n'),
           }
         : undefined;

--- a/runner/shared-interfaces.ts
+++ b/runner/shared-interfaces.ts
@@ -391,7 +391,7 @@ export interface RunDetails {
   /** Information about configured MCP servers, if any. */
   mcp?: {
     /** MCP servers that were configured. */
-    servers: {name: string; command: string; args: string[]}[];
+    servers: {name: string; command: string; args: string[], tools: string[], resources: string[]}[];
 
     /** Logs produced by all of the servers. */
     logs: string;


### PR DESCRIPTION
Lists the tools and resources associated with our MCP server, in the UI:

<img width="2364" height="802" alt="image" src="https://github.com/user-attachments/assets/6704202a-00a6-46a2-8111-6dba335f2644" />
