### PR TITLE
refactor: use short form of ngModel with a signal

### DIFF
--- a/report-app/src/app/shared/ai-assistant/ai-assistant.html
+++ b/report-app/src/app/shared/ai-assistant/ai-assistant.html
@@ -62,8 +62,7 @@
     <div class="input-container">
       <textarea
         #userInputElement
-        [ngModel]="userInput()"
-        (ngModelChange)="userInput.set($event)"
+        [(ngModel)]="userInput"
         placeholder="Ask a question about the report..."
         (keydown.enter)="$event.preventDefault(); send()"
         [readonly]="isLoading()"


### PR DESCRIPTION
I've accidentally retained an expanded version yesterday, updating the code to use a short version instead.