### PR TITLE
refactor: simplify signature of some functions

### DIFF
--- a/runner/orchestration/serve-testing-worker.ts
+++ b/runner/orchestration/serve-testing-worker.ts
@@ -2,7 +2,7 @@ import {ChildProcess, fork} from 'node:child_process';
 import path from 'node:path';
 import {Environment} from '../configuration/environment.js';
 import {ProgressLogger} from '../progress/progress-logger.js';
-import {RootPromptDefinition} from '../shared-interfaces.js';
+import {AssessmentConfig, RootPromptDefinition} from '../shared-interfaces.js';
 import {killChildProcessGracefully} from '../utils/kill-gracefully.js';
 import {
   ServeTestingResult,
@@ -15,6 +15,7 @@ import PQueue from 'p-queue';
 
 /** Attempts to run & test an eval app. */
 export async function serveAndTestApp(
+  config: AssessmentConfig,
   evalID: EvalID,
   gateway: Gateway<Environment>,
   appDirectoryPath: string,
@@ -23,10 +24,6 @@ export async function serveAndTestApp(
   workerConcurrencyQueue: PQueue,
   abortSignal: AbortSignal,
   progress: ProgressLogger,
-  skipScreenshots: boolean,
-  skipAxeTesting: boolean,
-  enableAutoCsp: boolean,
-  skipLighthouse: boolean,
   userJourneyAgentTaskInput?: BrowserAgentTaskInput,
 ): Promise<ServeTestingResult> {
   progress.log(rootPromptDef, 'serve-testing', `Testing the app`);
@@ -41,10 +38,10 @@ export async function serveAndTestApp(
       const serveParams: ServeTestingWorkerMessage = {
         serveUrl,
         appName: rootPromptDef.name,
-        enableAutoCsp,
-        includeAxeTesting: skipAxeTesting === false,
-        takeScreenshots: skipScreenshots === false,
-        includeLighthouseData: skipLighthouse === false,
+        enableAutoCsp: !!config.enableAutoCsp,
+        includeAxeTesting: config.skipAxeTesting === false,
+        takeScreenshots: config.skipScreenshots === false,
+        includeLighthouseData: config.skipLighthouse === false,
         userJourneyAgentTaskInput,
       };
 

--- a/runner/shared-interfaces.ts
+++ b/runner/shared-interfaces.ts
@@ -4,6 +4,32 @@ import type {UserJourneysResult} from './orchestration/user-journeys.js';
 import type {AutoRateResult} from './ratings/autoraters/auto-rate-shared.js';
 import type {Rating, RatingCategory} from './ratings/rating-types.js';
 import type {ServeTestingResult} from './workers/serve-testing/worker-types.js';
+import type {RunnerName} from './codegen/runner-creation.js';
+
+/** Configuration options necessary for kicking off an assessment run. */
+export interface AssessmentConfig {
+  model: string;
+  runner: RunnerName;
+  environmentConfigPath: string;
+  localMode: boolean;
+  limit: number;
+  concurrency: number | 'auto';
+  reportName: string;
+  skipScreenshots: boolean;
+  startMcp?: boolean;
+  ragEndpoint?: string;
+  outputDirectory?: string;
+  promptFilter?: string;
+  labels: string[];
+  skipAiSummary?: boolean;
+  skipAxeTesting: boolean;
+  enableUserJourneyTesting?: boolean;
+  enableAutoCsp?: boolean;
+  logging?: 'text-only' | 'dynamic';
+  autoraterModel?: string;
+  a11yRepairAttempts?: number;
+  skipLighthouse?: boolean;
+}
 
 /**
  * Represents a single prompt definition and extra metadata for it.


### PR DESCRIPTION
Switches to passing around an options object, instead of having functions with 18 arguments.