### PR TITLE
A couple of Lighthouse fixes

### DIFF
--- a/report-app/src/app/pages/report-viewer/lighthouse-category.ts
+++ b/report-app/src/app/pages/report-viewer/lighthouse-category.ts
@@ -24,7 +24,14 @@ import {Score} from '../../shared/score/score';
       @for (audit of audits; track audit.id) {
         <li>
           @if (audit.score != null) {
-            <score size="tiny" [total]="audit.score" [max]="1"/>
+            @if (audit.scoreDisplayMode === 'binary') {
+              @let isPass = audit.score === 1;
+              <span class="status-text material-symbols-outlined {{isPass ? 'success' : 'error'}}">
+                {{isPass ? 'check' : 'close'}}
+              </span>
+            } @else {
+              <score size="tiny" [total]="audit.score" [max]="1"/>
+            }
           }
           {{audit.title}}{{audit.displayValue ? ': ' + audit.displayValue : ''}}
 

--- a/runner/workers/serve-testing/lighthouse.ts
+++ b/runner/workers/serve-testing/lighthouse.ts
@@ -38,7 +38,19 @@ export async function getLighthouseData(
     const isAllowedDisplayMode = displayMode === 'binary' || displayMode === 'numeric';
 
     if (audit.score != null && isAllowedType && isAllowedDisplayMode) {
-      availableAudits.set(audit.id, audit);
+      availableAudits.set(audit.id, {
+        // Only capture the properties we care about in order to keep
+        // the report size small and avoid serialization errors.
+        id: audit.id,
+        score: audit.score,
+        title: audit.title,
+        displayValue: audit.displayValue ?? null,
+        description: audit.description,
+        explanation: audit.explanation ?? null,
+        scoreDisplayMode: displayMode,
+        numericValue: audit.numericValue ?? null,
+        numericUnit: audit.numericUnit ?? null,
+      });
     }
   }
 

--- a/runner/workers/serve-testing/worker-types.ts
+++ b/runner/workers/serve-testing/worker-types.ts
@@ -66,7 +66,17 @@ export type ServeTestingWorkerResponseMessage =
   | ServeTestingProgressLogMessage
   | ServeTestingResultMessage;
 
-export type LighthouseAudit = LighthouseRunnerResult['lhr']['audits']['x']; // Lighthouse doesn't export this so we need to dig for it.
+export interface LighthouseAudit {
+  id: string;
+  score: number | null;
+  title: string;
+  displayValue: string | null;
+  description: string | null;
+  explanation: string | null;
+  scoreDisplayMode: 'numeric' | 'binary';
+  numericValue: number | null;
+  numericUnit: string | null;
+}
 
 export interface LighthouseCategory {
   id: string;


### PR DESCRIPTION
Fixes the following issues with our Lighthouse results:
1. Only captures the properties we need from the audit object, instead of the full one. This keeps the report small and avoids serialization issues.
2. Properly displays binary audits in the report.