### PR TITLE
fix: incorrect lighthouse flag

### DIFF
--- a/runner/orchestration/serve-testing-worker.ts
+++ b/runner/orchestration/serve-testing-worker.ts
@@ -39,7 +39,7 @@ export async function serveAndTestApp(
         enableAutoCsp: !!config.enableAutoCsp,
         includeAxeTesting: config.skipAxeTesting === false,
         takeScreenshots: config.skipScreenshots === false,
-        includeLighthouseData: config.skipLighthouse === false,
+        includeLighthouseData: config.skipLighthouse !== true,
         userJourneyAgentTaskInput,
       };
 


### PR DESCRIPTION
Fixes that the condition for skipping Lighthouse didn't account for undefined.