### PR TITLE
fix: properly clean-up when evaluation CLI is aborted

### DIFF
--- a/runner/eval-cli.ts
+++ b/runner/eval-cli.ts
@@ -190,6 +190,13 @@ async function handler(cliArgs: Arguments<Options>): Promise<void> {
     process.exit(0);
   }
 
+  const abortCtrl = new AbortController();
+
+  process.on('SIGINT', () => abortCtrl.abort());
+  process.on('SIGTERM', () => abortCtrl.abort());
+  process.on('SIGTERM', () => abortCtrl.abort());
+  process.on('exit', () => abortCtrl.abort());
+
   try {
     const runInfo = await generateCodeAndAssess({
       runner: cliArgs.runner,
@@ -214,6 +221,7 @@ async function handler(cliArgs: Arguments<Options>): Promise<void> {
       skipLighthouse: cliArgs.skipLighthouse,
       maxBuildRepairAttempts: cliArgs.maxBuildRepairAttempts,
       maxTestRepairAttempts: cliArgs.maxTestRepairAttempts,
+      abortSignal: abortCtrl.signal,
     });
 
     logReportToConsole(runInfo);

--- a/runner/orchestration/executors/local-executor.ts
+++ b/runner/orchestration/executors/local-executor.ts
@@ -26,6 +26,7 @@ import {getPossiblePackageManagers} from '../../configuration/package-managers.j
 import {callWithTimeout} from '../../utils/timeout.js';
 import {executeCommand} from '../../utils/exec.js';
 import {cleanupBuildMessage} from '../../workers/builder/worker.js';
+import {combineAbortSignals} from '../../utils/abort-signal.js';
 
 let uniqueIDs = 0;
 
@@ -145,7 +146,7 @@ export class LocalExecutor implements Executor {
           `Testing ${rootPromptDef.name}`,
           timeoutAbort =>
             executeCommand(testCommand, appDirectoryPath, undefined, {
-              abortSignal: AbortSignal.any([abortSignal, timeoutAbort]),
+              abortSignal: combineAbortSignals(abortSignal, timeoutAbort),
             }),
           4, // 4min. This is a safety boundary. Lots of parallelism can slow-down.
         ),

--- a/runner/shared-interfaces.ts
+++ b/runner/shared-interfaces.ts
@@ -30,6 +30,7 @@ export interface AssessmentConfig {
   skipLighthouse?: boolean;
   maxTestRepairAttempts?: number;
   maxBuildRepairAttempts?: number;
+  abortSignal?: AbortSignal;
 }
 
 /**

--- a/runner/utils/abort-signal.ts
+++ b/runner/utils/abort-signal.ts
@@ -1,0 +1,3 @@
+export function combineAbortSignals(...signals: (AbortSignal | undefined)[]): AbortSignal {
+  return AbortSignal.any(signals.filter(s => s !== undefined));
+}


### PR DESCRIPTION
* Ensures we properly clean-up the evaluation CLI when user's abort
* Passes around the abort signals properly.