### PR TITLE
refactor: disambiguate project testing with serve testing

### DIFF
--- a/runner/orchestration/build-serve-test-loop.ts
+++ b/runner/orchestration/build-serve-test-loop.ts
@@ -184,7 +184,7 @@ export async function attemptBuildAndTest(
       testRepairAttempts++;
       progress.log(
         rootPromptDef,
-        'test',
+        'project-test',
         `Trying to repair test failures (attempt #${attemptId})...`,
       );
 

--- a/runner/orchestration/serve-testing-worker.ts
+++ b/runner/orchestration/serve-testing-worker.ts
@@ -25,7 +25,7 @@ export async function serveAndTestApp(
   progress: ProgressLogger,
   userJourneyAgentTaskInput?: BrowserAgentTaskInput,
 ): Promise<ServeTestingResult> {
-  progress.log(rootPromptDef, 'serve-testing', `Testing the app`);
+  progress.log(rootPromptDef, 'serve-testing', `Validating the running app`);
 
   const result = await env.executor.serveWebApplication(
     evalID,

--- a/runner/orchestration/test-worker.ts
+++ b/runner/orchestration/test-worker.ts
@@ -13,7 +13,7 @@ export async function runTest(
   workerConcurrencyQueue: PQueue,
   progress: ProgressLogger,
 ): Promise<TestExecutionResult | null> {
-  progress.log(rootPromptDef, 'test', `Running tests`);
+  progress.log(rootPromptDef, 'project-test', `Running project tests`);
 
   try {
     const result = await env.executor.executeProjectTests(

--- a/runner/progress/dynamic-progress-logger.ts
+++ b/runner/progress/dynamic-progress-logger.ts
@@ -148,7 +148,7 @@ export class DynamicProgressLogger implements ProgressLogger {
     switch (type) {
       case 'success':
       case 'serve-testing':
-      case 'test':
+      case 'project-test':
       case 'build':
         return chalk.green;
       case 'error':

--- a/runner/progress/progress-logger.ts
+++ b/runner/progress/progress-logger.ts
@@ -5,7 +5,7 @@ import {AssessmentResult, RootPromptDefinition} from '../shared-interfaces.js';
 export type ProgressType =
   | 'codegen'
   | 'build'
-  | 'test'
+  | 'project-test'
   | 'serve-testing'
   | 'success'
   | 'error'
@@ -19,7 +19,7 @@ export function progressTypeToIcon(type: ProgressType): string {
       return '🤖';
     case 'build':
       return '🔨';
-    case 'test':
+    case 'project-test':
       return '🧪';
     case 'serve-testing':
       return '🌊';


### PR DESCRIPTION
Right now it's easy to think project tests are running, while actually the served app is being tested.