### PR TITLE
refactor: revert at link support but expose an API for post-processing system prompts

### DIFF
--- a/examples/environments/remote_env/fake-executor.ts
+++ b/examples/environments/remote_env/fake-executor.ts
@@ -7,6 +7,7 @@ import {
   LlmGenerateFilesRequest,
   LlmResponse,
   LlmResponseFile,
+  replaceAtReferencesInPrompt,
   RootPromptDefinition,
 } from '../../../runner';
 import {ProgressLogger} from '../../../runner/progress/progress-logger';
@@ -109,6 +110,14 @@ export class FakeRemoteExecutor implements Executor {
       displayName: 'Fake Executor',
       mcpServersLaunched: 0,
     };
+  }
+
+  async postProcessSystemPrompt(prompt: string, environmentRootPath: string) {
+    return replaceAtReferencesInPrompt(
+      prompt,
+      `${environmentRootPath}/prompt.md`,
+      environmentRootPath,
+    );
   }
 
   async destroy() {}

--- a/examples/environments/remote_env/other-file.md
+++ b/examples/environments/remote_env/other-file.md
@@ -1,3 +1,3 @@
 Use XYZ.
 
-@./other-file-2.md
+@/other-file-2.md

--- a/examples/environments/remote_env/system-instructions.md
+++ b/examples/environments/remote_env/system-instructions.md
@@ -3,4 +3,4 @@ Follow instructions below CAREFULLY:
 - Code MUST be implemented in my super secret framework.
 - Put the component code inside `src/app/app.ts`
 
-@./other-file.md
+@../remote_env/other-file.md

--- a/runner/configuration/prompt-templating.ts
+++ b/runner/configuration/prompt-templating.ts
@@ -14,8 +14,7 @@ function initializeHandlebars() {
     }
 
     const fullPath = path.join(dirname(ctx.containingFile), ctx.file);
-    let content = readFileSync(fullPath, 'utf8');
-    content = processAtFileReferencesSync(content, fullPath);
+    const content = readFileSync(fullPath, 'utf8');
 
     // Recursively support `embed`.
     return Handlebars.compile(content, {strict: true})({
@@ -39,8 +38,6 @@ export function renderPromptTemplate<T extends {containingFile: string | null}>(
   content: string,
   ctx: T,
 ) {
-  content = ctx.containingFile ? processAtFileReferencesSync(content, ctx.containingFile) : content;
-
   const template = Handlebars.compile(content, {strict: true});
   const contextFiles: string[] = [];
   const result = template(ctx, {
@@ -81,36 +78,4 @@ export function renderPromptTemplate<T extends {containingFile: string | null}>(
     result,
     contextFiles,
   };
-}
-
-function processAtFileReferencesSync(content: string, containingFile: string): string {
-  let newContent = content;
-  let match;
-  // Match all `@./<file-path>` or `@/<file-path>` occurrences.
-  // If someone intends to write such text in their prompt, they could overcome this
-  // by indenting the string, or adding arbitrary characters before front.
-  const regex = /^@(\.?\/[^\s]+)/gm;
-  const containingFileDir = dirname(containingFile);
-
-  while ((match = regex.exec(newContent)) !== null) {
-    const filePath = match[1];
-    const fullPath = resolve(containingFileDir, filePath);
-    let replacement: string;
-    try {
-      replacement = readFileSync(fullPath, 'utf8');
-      // Note: If we start searching the match start, where the new embedded content begins,
-      // we can trivially. process nested embeds via the `@` syntax.
-    } catch (e) {
-      throw new Error(
-        `Unexpected error while embedding \`${match[0]}\` reference in ${containingFile}. ` +
-          `Error: ${e}`,
-      );
-    }
-
-    newContent =
-      newContent.substring(0, match.index) +
-      processAtFileReferencesSync(replacement, fullPath) +
-      newContent.substring(regex.lastIndex);
-  }
-  return newContent;
 }

--- a/runner/index.ts
+++ b/runner/index.ts
@@ -48,3 +48,4 @@ export {DynamicProgressLogger} from './progress/dynamic-progress-logger.js';
 export {NoopProgressLogger} from './progress/noop-progress-logger.js';
 export {TextProgressLogger} from './progress/text-progress-logger.js';
 export {type ServeTestingResult} from './workers/serve-testing/worker-types.js';
+export {replaceAtReferencesInPrompt} from './utils/prompt-at-references.js';

--- a/runner/orchestration/codegen.ts
+++ b/runner/orchestration/codegen.ts
@@ -98,7 +98,7 @@ export async function repairCodeWithAI(
   progress: ProgressLogger,
   repairType: 'build' | 'test',
 ): Promise<LlmResponse> {
-  const repairSystemInstructions = env.systemPromptRepair();
+  const repairSystemInstructions = await env.systemPromptRepair();
   const repairPrompt = [
     ...errors.map(({errorContext, errorMessage}) =>
       [errorContext, '```', errorMessage, '```'].join('\n'),

--- a/runner/orchestration/executors/executor.ts
+++ b/runner/orchestration/executors/executor.ts
@@ -104,6 +104,12 @@ export const executorSchema = z.object({
       }),
     ),
   ),
+  postProcessSystemPrompt: z
+    .function(
+      z.tuple([z.string().describe('Prompt'), z.string().describe('Environment root path')]),
+      z.promise(z.string()),
+    )
+    .optional(),
   destroy: z.function(z.tuple([]), z.promise(z.void())),
   getExecutorInfo: z.function(
     z.tuple([]),

--- a/runner/run-cli.ts
+++ b/runner/run-cli.ts
@@ -146,13 +146,14 @@ async function resolveConfig(options: Options) {
     );
   }
 
-  const rootPromptDef = environment.executablePrompts.find(p => p.name === options.prompt);
+  const executablePrompts = await environment.executablePrompts();
+  const rootPromptDef = executablePrompts.find(p => p.name === options.prompt);
 
   if (!rootPromptDef) {
     throw new UserFacingError(
       `Environment "${environment.displayName}" does not have a prompt with a name of "${options.prompt}".\n` +
         `The following prompts are available:\n` +
-        environment.executablePrompts.map(p => ` - ${p.name}`).join('\n'),
+        executablePrompts.map(p => ` - ${p.name}`).join('\n'),
     );
   }
 

--- a/runner/utils/prompt-at-references.ts
+++ b/runner/utils/prompt-at-references.ts
@@ -1,0 +1,59 @@
+import {readFile} from 'node:fs/promises';
+import {dirname, join, resolve} from 'node:path';
+
+/**
+ * Finds all `@<file-link>` in given content and recursively embeds the
+ * references files.
+ *
+ * @param content The starting prompt which may contain `@` file links.
+ * @param containingFile The file path of the given content.
+ * @param fakeRoot An optional fake root to control where absolute `@/<path>` links should start.
+ */
+export async function replaceAtReferencesInPrompt(
+  content: string,
+  containingFile: string,
+  fakeRoot?: string,
+): Promise<string> {
+  let newContent = content;
+  // Match all `@./<file-path>`, `@../<file-path>` or `@/<file-path>` occurrences.
+  // If someone intends to write such text in their prompt, they could overcome this
+  // by indenting the string, or adding arbitrary characters before front.
+  const regex = /^@(\.?\.?\/[^\s]+)/gm;
+  const containingFileDir = dirname(containingFile);
+  const matches = [...newContent.matchAll(regex)];
+
+  const replacements = await Promise.all(
+    matches.map(async match => {
+      let filePath = match[1];
+      if (filePath.startsWith('/') && fakeRoot) {
+        filePath = join(fakeRoot, filePath);
+      }
+
+      const fullPath = resolve(containingFileDir, filePath);
+      try {
+        const replacementContent = await readFile(fullPath, 'utf8');
+        // Note: If we start searching the match start, where the new embedded content begins,
+        // we can trivially. process nested embeds via the `@` syntax.
+        return {
+          start: match.index!,
+          end: match.index! + match[0].length,
+          content: await replaceAtReferencesInPrompt(replacementContent, fullPath, fakeRoot),
+        };
+      } catch (e) {
+        throw new Error(
+          `Unexpected error while embedding \`${match[0]}\` reference in ${containingFile}. ` +
+            `Error: ${e}`,
+        );
+      }
+    }),
+  );
+
+  // Apply replacements in reverse order to avoid index shifts.
+  for (const replacement of replacements.sort((a, b) => b.start - a.start)) {
+    newContent =
+      newContent.substring(0, replacement.start) +
+      replacement.content +
+      newContent.substring(replacement.end);
+  }
+  return newContent;
+}


### PR DESCRIPTION
* We find the at-link support to be non-ideal given requirements inside Google, or differences by different agents— so we revert it. We don't expect any usages as it was just available for a very short time (less than 2 hours)

* We will expose a hook for advanced executors to post-process system prompts. We can evolve that API as we detect more need.