### PR TITLE
feat: provide system instructions separately via Genkit.generate system opt param

### DIFF
--- a/runner/codegen/genkit/genkit-runner.ts
+++ b/runner/codegen/genkit/genkit-runner.ts
@@ -68,7 +68,8 @@ export class GenkitRunner implements LlmRunner {
   ): Promise<LocalLlmGenerateFilesResponse> {
     const requestOptions: LocalLlmConstrainedOutputGenerateRequestOptions = {
       ...options,
-      prompt: options.context.combinedPrompt,
+      prompt: options.context.executablePrompt,
+      systemPrompt: options.context.systemInstructions,
       schema: z.object({
         outputFiles: z.array(
           z.object({
@@ -145,6 +146,7 @@ export class GenkitRunner implements LlmRunner {
 
           const response = await this.genkitInstance.generate({
             prompt: options.prompt,
+            system: options.systemPrompt,
             model,
             output: schema
               ? {

--- a/runner/codegen/llm-runner.ts
+++ b/runner/codegen/llm-runner.ts
@@ -96,6 +96,8 @@ interface BaseLlmRequestOptions {
 export interface LocalLlmGenerateTextRequestOptions extends BaseLlmRequestOptions {
   /** Prompt to send. */
   prompt: string;
+  /** System prompt. */
+  systemPrompt?: string;
 }
 
 /** Context needed for an file generation context. */
@@ -123,6 +125,8 @@ export interface LocalLlmConstrainedOutputGenerateRequestOptions<
 > extends BaseLlmRequestOptions {
   /** Prompt to send. */
   prompt: string;
+  /** System prompt. */
+  systemPrompt?: string;
   /** Schema that the response should conform to. */
   schema: T;
 }


### PR DESCRIPTION
Provide system instructions as a separate prompt via the `system` option parameter of `Genkit.generate` instead of concatenating them to the main executable prompt.