### PR TITLE
fix: gracefully handle killing errors

### DIFF
--- a/runner/orchestration/executors/local-executor.ts
+++ b/runner/orchestration/executors/local-executor.ts
@@ -12,7 +12,7 @@ import {
   RootPromptDefinition,
   TestExecutionResult,
 } from '../../shared-interfaces.js';
-import {killChildProcessGracefully} from '../../utils/kill-gracefully.js';
+import {killChildProcessWithSigterm} from '../../utils/kill-gracefully.js';
 import {
   BuildResult,
   BuildWorkerMessage,
@@ -111,11 +111,19 @@ export class LocalExecutor implements Executor {
           child.send(buildParams);
 
           child.on('message', async (result: BuildWorkerResponseMessage) => {
-            await killChildProcessGracefully(child);
+            try {
+              await killChildProcessWithSigterm(child);
+            } catch (e) {
+              progress.debugLog(`Error while killing build worker: ${e}`);
+            }
             resolve(result.payload);
           });
           child.on('error', async err => {
-            await killChildProcessGracefully(child);
+            try {
+              await killChildProcessWithSigterm(child);
+            } catch (e) {
+              progress.debugLog(`Error while killing build worker: ${e}`);
+            }
             reject(err);
           });
         }),

--- a/runner/progress/dynamic-progress-logger.ts
+++ b/runner/progress/dynamic-progress-logger.ts
@@ -144,6 +144,10 @@ export class DynamicProgressLogger implements ProgressLogger {
     }
   }
 
+  debugLog(message: string): void {
+    // TODO: Implement debug logging in dynamic progress logging.
+  }
+
   private getColorFunction(type: ProgressType): (value: string) => string {
     switch (type) {
       case 'success':

--- a/runner/progress/noop-progress-logger.ts
+++ b/runner/progress/noop-progress-logger.ts
@@ -6,4 +6,5 @@ export class NoopProgressLogger implements ProgressLogger {
   finalize(): void {}
   log(): void {}
   evalFinished(): void {}
+  debugLog(): void {}
 }

--- a/runner/progress/progress-logger.ts
+++ b/runner/progress/progress-logger.ts
@@ -58,4 +58,9 @@ export interface ProgressLogger {
    * @param details Additional information about the event.
    */
   log(prompt: RootPromptDefinition, type: ProgressType, message: string, details?: string): void;
+
+  /**
+   * Log information for debugging.
+   */
+  debugLog(message: string): void;
 }

--- a/runner/progress/text-progress-logger.ts
+++ b/runner/progress/text-progress-logger.ts
@@ -24,4 +24,10 @@ export class TextProgressLogger implements ProgressLogger {
     // It's handy to know how many apps are done when one completes.
     console.log(`[${prompt.name}] 🏁 Done (${++this.done}/${this.total})`.trim());
   }
+
+  debugLog(message: string): void {
+    if (process.env.DEBUG === '1') {
+      console.log(`DEBUG: ${message}`);
+    }
+  }
 }

--- a/runner/run-cli.ts
+++ b/runner/run-cli.ts
@@ -180,6 +180,7 @@ class ErrorOnlyProgressLogger implements ProgressLogger {
   initialize(): void {}
   finalize(): void {}
   evalFinished(): void {}
+  debugLog(): void {}
 
   log(_: unknown, type: ProgressType, message: string, details?: string) {
     if (type === 'error') {

--- a/runner/utils/kill-gracefully.ts
+++ b/runner/utils/kill-gracefully.ts
@@ -13,7 +13,7 @@ function treeKillPromise(pid: number, signal: string): Promise<void> {
   });
 }
 
-export function killChildProcessGracefully(
+export function killChildProcessWithSigterm(
   child: ChildProcess,
   timeoutInMs = 1000 * 10, // 10s
 ): Promise<void> {

--- a/runner/workers/serve-testing/serve-app.ts
+++ b/runner/workers/serve-testing/serve-app.ts
@@ -1,5 +1,5 @@
 import {ChildProcess, exec} from 'child_process';
-import {killChildProcessGracefully} from '../../utils/kill-gracefully.js';
+import {killChildProcessWithSigterm} from '../../utils/kill-gracefully.js';
 import {cleanupBuildMessage} from '../builder/worker.js';
 import {ProgressLogger} from '../../progress/progress-logger.js';
 import {RootPromptDefinition} from '../../shared-interfaces.js';
@@ -96,7 +96,13 @@ export async function serveApp<T>(
         'Terminating browser process for app',
         `(PID: ${serveProcess.pid})`,
       );
-      await killChildProcessGracefully(serveProcess);
+
+      try {
+        await killChildProcessWithSigterm(serveProcess);
+      } catch (e) {
+        progress.debugLog(`Error while killing serve process: ${e}`);
+      }
+
       serveProcess = null;
     }
   }


### PR DESCRIPTION
Currently WCS seems to be exiting abruptly when a process isn't killed as expected. This should be a non-error.

```
file:///usr/local/google/home/pgschwendtner/projects/llm-codegen-quality/node_modules/.pnpm/web-codegen-scorer@0.0.20_5
        rejectTimeoutId = setTimeout(() => reject(new Error('Child process did not exit gracefully within the timeout.')), timeoutInMs * 2);
                                                  ^

Error: Child process did not exit gracefully within the timeout.
    at Timeout._onTimeout (file:///usr/local/google/home/pgschwendtner/projects/llm-codegen-quality/node_modules/.pnpm/web-codegen-scorer@0.0.20_@google-cloud+firest)
    at listOnTimeout (node:internal/timers:594:17)
    at process.processTimers (node:internal/timers:529:7)
```