### PR TITLE
feat: support passing `metadata` to prompts

### DIFF
--- a/examples/environments/remote_env/config.js
+++ b/examples/environments/remote_env/config.js
@@ -4,15 +4,51 @@
  * @import {EnvironmentConfig} from 'web-codegen-scorer';
  */
 
-import {getBuiltInRatings} from 'web-codegen-scorer';
+import {
+  EvalPromptWithMetadata,
+  getBuiltInRatings,
+  RatingKind,
+  RatingCategory,
+  RatingState,
+} from 'web-codegen-scorer';
 import {FakeRemoteExecutor} from './fake-executor';
 
 /** @type {EnvironmentConfig} */
 export default {
   displayName: 'Remote Env (example)',
   clientSideFramework: 'angular',
-  ratings: getBuiltInRatings(),
+  ratings: [
+    ...getBuiltInRatings(),
+    {
+      name: 'Test Metadata Rating',
+      id: 'test-metadata-rating',
+      kind: RatingKind.PER_BUILD,
+      category: RatingCategory.MEDIUM_IMPACT,
+      description: 'Testing the metadata of prompts',
+      scoreReduction: '100%',
+      rate: ctx => {
+        const metadata = /** @type {{goldenURL: string}} */ (ctx.prompt.metadata);
+        const found = ctx.generatedFiles.some(f => f.code.includes(metadata.goldenURL));
+
+        return {
+          state: RatingState.EXECUTED,
+          coefficient: found ? 1 : 0,
+          message: found ? `${metadata.goldenURL} found!` : `${metadata.goldenURL} not found!`,
+        };
+      },
+    },
+  ],
   generationSystemPrompt: './system-instructions.md',
-  executablePrompts: ['../../prompts/**/*.md'],
+  executablePrompts: [
+    new EvalPromptWithMetadata(
+      'test-app',
+      `Create the Angular documentation website. Make sure you add a link to \`angular.dev\` in there.`,
+      {
+        metadata: {
+          goldenURL: 'angular.dev',
+        },
+      },
+    ),
+  ],
   executor: new FakeRemoteExecutor(),
 };

--- a/examples/environments/remote_env/fake-executor.ts
+++ b/examples/environments/remote_env/fake-executor.ts
@@ -26,7 +26,7 @@ export class FakeRemoteExecutor implements Executor {
   async performFakeLlmRequest(): Promise<LlmResponse> {
     return {
       success: true,
-      outputFiles: [{code: 'Works!', filePath: 'main.ts'}],
+      outputFiles: [{code: 'angular.dev Works', filePath: 'main.ts'}],
       reasoning: '',
       errors: [],
       usage: {inputTokens: 0, totalTokens: 0, outputTokens: 0},

--- a/runner/configuration/environment-config.ts
+++ b/runner/configuration/environment-config.ts
@@ -2,7 +2,7 @@ import z from 'zod';
 import {createMessageBuilder, fromError} from 'zod-validation-error/v3';
 import {UserFacingError} from '../utils/errors.js';
 import {ratingSchema} from '../ratings/rating-types.js';
-import {MultiStepPrompt} from './multi-step-prompt.js';
+import {EvalPrompt, EvalPromptWithMetadata, MultiStepPrompt} from './prompts.js';
 import {executorSchema} from '../orchestration/executors/executor.js';
 import {
   LocalExecutorConfig,
@@ -46,6 +46,8 @@ export const environmentConfigSchema = z.object({
         ratings: z.array(ratingSchema).optional(),
       }),
       z.custom<MultiStepPrompt>(data => data instanceof MultiStepPrompt),
+      z.custom<EvalPrompt>(data => data instanceof EvalPrompt),
+      z.custom<EvalPromptWithMetadata<unknown>>(data => data instanceof EvalPromptWithMetadata),
     ]),
   ),
   /**

--- a/runner/configuration/multi-step-prompt.ts
+++ b/runner/configuration/multi-step-prompt.ts
@@ -1,9 +1,0 @@
-import {Rating} from '../ratings/rating-types.js';
-
-/** Definition of a multi-step prompt. */
-export class MultiStepPrompt {
-  constructor(
-    readonly directoryPath: string,
-    readonly stepRatings: Record<string, Rating[]> = {},
-  ) {}
-}

--- a/runner/configuration/prompts.ts
+++ b/runner/configuration/prompts.ts
@@ -1,0 +1,36 @@
+import {Rating} from '../ratings/rating-types.js';
+
+export interface EvalPromptOptions<M> {
+  metadata: M;
+  contextFilePatterns?: string[];
+  extraRatings?: Rating[];
+}
+
+/** Definition of a single-step prompt with metadata. */
+export class EvalPromptWithMetadata<Metadata> {
+  constructor(
+    readonly name: string,
+    readonly text: string,
+    readonly opts: EvalPromptOptions<Metadata>,
+  ) {}
+}
+
+/** Definition of a single-step prompt. */
+export class EvalPrompt extends EvalPromptWithMetadata<undefined> {
+  constructor(
+    name: string,
+    text: string,
+    opts: Omit<EvalPromptOptions<undefined>, 'metadata'> = {},
+  ) {
+    super(name, text, {...opts, metadata: undefined});
+  }
+}
+
+/** Definition of a multi-step prompt. */
+export class MultiStepPrompt {
+  constructor(
+    readonly directoryPath: string,
+    readonly stepRatings: Record<string, Rating[]> = {},
+    readonly stepMetadata: Record<string, unknown> = {},
+  ) {}
+}

--- a/runner/index.ts
+++ b/runner/index.ts
@@ -9,7 +9,7 @@ export * from './ratings/built-in.js';
 export * from './ratings/rating-types.js';
 export * from './ratings/built-in-ratings/index.js';
 export {calculateBuildAndCheckStats, isPositiveScore} from './ratings/stats.js';
-export {MultiStepPrompt} from './configuration/multi-step-prompt.js';
+export {MultiStepPrompt, EvalPrompt, EvalPromptWithMetadata} from './configuration/prompts.js';
 export {
   BuildErrorType,
   BuildResultStatus,

--- a/runner/ratings/built-in-ratings/sufficient-generated-files-rating.ts
+++ b/runner/ratings/built-in-ratings/sufficient-generated-files-rating.ts
@@ -8,8 +8,8 @@ export const sufficientGeneratedFilesRating: PerBuildRating = {
   id: 'common-generated-file-count',
   scoreReduction: '100%',
   kind: RatingKind.PER_BUILD,
-  rate: ({generatedFileCount}) => ({
+  rate: ({generatedFiles}) => ({
     state: RatingState.EXECUTED,
-    coefficient: generatedFileCount > 0 ? 1 : 0,
+    coefficient: generatedFiles.length > 0 ? 1 : 0,
   }),
 };

--- a/runner/ratings/rating-types.ts
+++ b/runner/ratings/rating-types.ts
@@ -46,6 +46,11 @@ export const CATEGORY_NAMES = {
   [RatingCategory.LOW_IMPACT]: 'Low Impact',
 };
 
+const ratingCommonContextFields = {
+  ratingsResult: z.record(z.custom<IndividualAssessment | SkippedIndividualAssessment>()),
+  prompt: z.custom<PromptDefinition>(),
+};
+
 const ratingSchemaCommonFields = {
   category: z.custom<RatingCategory>(),
   scoreReduction: z.custom<`${number}%`>(),
@@ -63,13 +68,13 @@ const perBuildRatingSchema = z
       .args(
         z.strictObject({
           buildResult: z.custom<BuildResult>(),
+          generatedFiles: z.custom<LlmResponseFile[]>(),
           serveResult: z.custom<ServeTestingResult | null>(),
           repairAttempts: z.number(),
           testResult: z.custom<TestExecutionResult | null>(),
           testRepairAttempts: z.number(),
           axeRepairAttempts: z.number(),
-          generatedFileCount: z.number(),
-          ratingsResult: z.record(z.custom<IndividualAssessment | SkippedIndividualAssessment>()),
+          ...ratingCommonContextFields,
         }),
       )
       .returns(z.custom<PerBuildRatingResult>()),
@@ -83,9 +88,9 @@ const perFileRatingSchema = z
     rate: z
       .function()
       .args(
-        z.string(),
-        z.string().optional(),
-        z.record(z.custom<IndividualAssessment | SkippedIndividualAssessment>()),
+        z.string().describe('Code'),
+        z.string().optional().describe('File path'),
+        z.object(ratingCommonContextFields).describe('Context'),
       )
       .returns(z.custom<PerFileRatingResult>()),
     filter: z.union([

--- a/runner/shared-interfaces.ts
+++ b/runner/shared-interfaces.ts
@@ -36,7 +36,7 @@ export interface AssessmentConfig {
 /**
  * Represents a single prompt definition and extra metadata for it.
  */
-export interface PromptDefinition {
+export interface PromptDefinition<Metadata = unknown> {
   /**
    * A descriptive name for the prompt, used for identification (e.g., file naming).
    */
@@ -67,6 +67,14 @@ export interface PromptDefinition {
    * Relative paths to files that should be passed as context to LLM calls.
    */
   contextFilePatterns: string[];
+
+  /**
+   * Additional metadata attached to the given prompt.
+   *
+   * Metadata can be attached in advanced environments and allows for advanced
+   * raters to leverage metadata to e.g. compare with golden output.
+   */
+  metadata: Metadata;
 }
 
 /**


### PR DESCRIPTION
* This allows more advanced custom ratings that leverage metadata that is tied to specific app prompts. e.g. golden response comparisons.

e.g.

```ts
new EvalPrompt(`Generate hello world app`, {
  metadata: {
    goldenFiles: [...],
    featuresToAutorateFor: ['Is there a hello world greeting?'],
  }
})
```