### PR TITLE
refactor: print when a served app is running

### DIFF
--- a/runner/orchestration/serve-testing-worker.ts
+++ b/runner/orchestration/serve-testing-worker.ts
@@ -38,6 +38,11 @@ export async function serveAndTestApp(
       rootPromptDef,
       progress,
       async serveUrl => {
+        progress.log(
+          rootPromptDef,
+          'serve-testing',
+          `Validating the running app (URL: ${serveUrl})`,
+        );
         const serveParams: ServeTestingWorkerMessage = {
           serveUrl,
           appName: rootPromptDef.name,


### PR DESCRIPTION
This is a useful indication as starting the server can take a while, but it's good to know when it's ready and have a way to also jump onto the page.