### PR TITLE
refactor: avoid confusion from runtime console errors

### DIFF
--- a/runner/workers/serve-testing/puppeteer.ts
+++ b/runner/workers/serve-testing/puppeteer.ts
@@ -45,7 +45,10 @@ export async function runAppInPuppeteer(
       if (message.type() !== 'error') return;
 
       if (!message.text().includes('JSHandle@error')) {
-        progressLog('error', `${message.type().substring(0, 3).toUpperCase()} ${message.text()}`);
+        progressLog(
+          'error',
+          `Runtime Error: ${message.type().substring(0, 3).toUpperCase()} ${message.text()}`,
+        );
         return;
       }
       const messages = await Promise.all(


### PR DESCRIPTION
Runtime errors from Puppeteer are directly forwarded to the progress logger. This can be quickly confusing if there are errors. We should make it a bit more obvious via a consistent prefix.