### PR TITLE
feat: allow running WCS as standalone auto-rater without second LLM

### DIFF
--- a/runner/ratings/rate-code.ts
+++ b/runner/ratings/rate-code.ts
@@ -29,6 +29,7 @@ import {GenkitRunner} from '../codegen/genkit/genkit-runner.js';
 import {ProgressLogger} from '../progress/progress-logger.js';
 import {UserFacingError} from '../utils/errors.js';
 import {ServeTestingResult} from '../workers/serve-testing/worker-types.js';
+import assert from 'assert';
 
 interface FileOrEmbeddedSyntheticFile {
   /**
@@ -45,7 +46,7 @@ interface FileOrEmbeddedSyntheticFile {
 type CategorizedFiles = Record<PerFileRatingContentType, FileOrEmbeddedSyntheticFile[]>;
 
 export async function rateGeneratedCode(
-  llm: GenkitRunner,
+  autoraterLlm: GenkitRunner | null,
   environment: Environment,
   currentPromptDef: PromptDefinition,
   fullPromptText: string,
@@ -107,12 +108,13 @@ export async function rateGeneratedCode(
         categorizedFiles ??= splitFilesIntoCategories(outputFiles);
         result = await runPerFileRating(currentPromptDef, current, categorizedFiles, ratingsResult);
       } else if (current.kind === RatingKind.LLM_BASED) {
+        assert(autoraterLlm !== null, 'Expected an auto-rater LLM to be available.');
         result = await runLlmBasedRating(
           environment,
           current,
           fullPromptText,
           currentPromptDef,
-          llm,
+          autoraterLlm,
           outputFiles,
           buildResult,
           serveTestingResult,

--- a/runner/reporting/report-ai-summary.ts
+++ b/runner/reporting/report-ai-summary.ts
@@ -10,7 +10,7 @@ export async function summarizeReportWithAI(
   const model = 'gemini-2.5-flash-lite';
 
   if (!llm.getSupportedModels().includes(model)) {
-    return null;
+    throw new Error(`Unable to generate AI summary due to unsupported model: ${model}`);
   }
 
   return chatWithReportAI(


### PR DESCRIPTION
In some cases it's useful to run WCS with a custom executor that provides pre-scraped LLM output for rating. These environments might not have access to a Gemini Key for auto-rating. In such cases, WCS should be smart enough to detect that there are no LLM-autorater ratings and not require a Gemini key (by calling `getRunnerByName()`).