### PR TITLE
refactor: support extending local executor without creating genkit

### DIFF
--- a/runner/codegen/noop-unimplemented-runner.ts
+++ b/runner/codegen/noop-unimplemented-runner.ts
@@ -1,0 +1,36 @@
+import {
+  LlmRunner,
+  LocalLlmConstrainedOutputGenerateResponse,
+  LocalLlmGenerateFilesResponse,
+  LocalLlmGenerateTextResponse,
+} from './llm-runner.js';
+
+/**
+ * Noop runner that is useful for creating a `LocalExecutor`
+ * that doesn't leverage a runner specified to WCS.
+ *
+ * E.g. a custom executor that uses pre-scraped LLM output will override
+ * corresponding generation methods in the `Executor` but doesn't want
+ * the Genkit LLM runner to be instantiated just to expect a `GEMINI_API_KEY`.
+ */
+export class NoopUnimplementedRunner implements LlmRunner {
+  displayName = 'noop-unimplemented';
+  id = 'noop-unimplemented';
+  hasBuiltInRepairLoop = true;
+
+  generateFiles(): Promise<LocalLlmGenerateFilesResponse> {
+    throw new Error('Method not implemented.');
+  }
+  generateText(): Promise<LocalLlmGenerateTextResponse> {
+    throw new Error('Method not implemented.');
+  }
+  generateConstrained(): Promise<LocalLlmConstrainedOutputGenerateResponse<any>> {
+    throw new Error('Method not implemented.');
+  }
+  getSupportedModels(): string[] {
+    throw new Error('Method not implemented.');
+  }
+  async dispose(): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/runner/codegen/runner-creation.ts
+++ b/runner/codegen/runner-creation.ts
@@ -3,12 +3,14 @@ import type {GeminiCliRunner} from './gemini-cli-runner.js';
 import type {ClaudeCodeRunner} from './claude-code-runner.js';
 import type {GenkitRunner} from './genkit/genkit-runner.js';
 import type {CodexRunner} from './codex-runner.js';
+import type {NoopUnimplementedRunner} from './noop-unimplemented-runner.js';
 
 interface AvailableRunners {
   genkit: GenkitRunner;
   'gemini-cli': GeminiCliRunner;
   'claude-code': ClaudeCodeRunner;
   'codex': CodexRunner;
+  'noop-unimplemented': NoopUnimplementedRunner;
 }
 
 /** Names of supported runners. */
@@ -35,6 +37,10 @@ export async function getRunnerByName<T extends RunnerName>(name: T): Promise<Av
       );
     case 'codex':
       return import('./codex-runner.js').then(m => new m.CodexRunner() as AvailableRunners[T]);
+    case 'noop-unimplemented':
+      return import('./noop-unimplemented-runner.js').then(
+        m => new m.NoopUnimplementedRunner() as AvailableRunners[T],
+      );
     default:
       throw new UserFacingError(`Unsupported runner ${name}`);
   }

--- a/runner/orchestration/executors/local-executor.ts
+++ b/runner/orchestration/executors/local-executor.ts
@@ -36,7 +36,7 @@ export class LocalExecutor implements Executor {
 
   constructor(
     public config: LocalExecutorConfig,
-    runnerName: RunnerName = 'genkit',
+    runnerName: RunnerName = 'noop-unimplemented',
   ) {
     this.llm = getRunnerByName(runnerName);
   }


### PR DESCRIPTION
Currently `extends LocalExecutor` always means instantiating a Genkit instance. This makes it hard to come up with a custom prescrap LLM output executor that doesn't involve any LLM.