### PR TITLE
feat: support annotating/labeling ratings for future grouping

### DIFF
--- a/runner/ratings/built-in-ratings/axe-rating.ts
+++ b/runner/ratings/built-in-ratings/axe-rating.ts
@@ -20,6 +20,7 @@ export const axeRating: PerBuildRating = {
   name: 'Axe Accessibility Violations',
   description: 'Checks for accessibility violations using the Axe-core engine.',
   category: RatingCategory.MEDIUM_IMPACT,
+  groupingLabels: ['accessibility'],
   id: 'axe-a11y',
   scoreReduction: '10%',
   rate: ({serveResult, axeRepairAttempts}) => {

--- a/runner/ratings/built-in-ratings/code-quality-rating.ts
+++ b/runner/ratings/built-in-ratings/code-quality-rating.ts
@@ -7,6 +7,7 @@ export const codeQualityRating: LLMBasedRating = {
   name: 'Code Quality (LLM-rated)',
   description: `Rates the app's source code via LLM`,
   category: RatingCategory.MEDIUM_IMPACT,
+  groupingLabels: ['llm-judge'],
   id: 'common-autorater-code-quality',
   scoreReduction: '30%',
   rate: async ctx => {

--- a/runner/ratings/built-in-ratings/no-dangerously-set-inner-html-rating.ts
+++ b/runner/ratings/built-in-ratings/no-dangerously-set-inner-html-rating.ts
@@ -16,6 +16,7 @@ export const NoDangerouslySetInnerHtmlRating: PerFileRating = {
   name: RATING_NAME,
   id: 'no-dangerously-set-inner-html',
   category: RatingCategory.MEDIUM_IMPACT,
+  groupingLabels: ['security'],
   scoreReduction: '50%',
   description: RATING_DESCRIPTION,
   filter: {

--- a/runner/ratings/built-in-ratings/no-inner-html-bindings-rating.ts
+++ b/runner/ratings/built-in-ratings/no-inner-html-bindings-rating.ts
@@ -16,6 +16,7 @@ export const NoInnerHtmlBindingsRating: PerFileRating = {
   name: RATING_NAME,
   id: 'no-inner-html-bindings',
   category: RatingCategory.MEDIUM_IMPACT,
+  groupingLabels: ['security'],
   scoreReduction: '50%',
   description: RATING_DESCRIPTION,
   filter: {

--- a/runner/ratings/built-in-ratings/no-runtime-errors-rating.ts
+++ b/runner/ratings/built-in-ratings/no-runtime-errors-rating.ts
@@ -7,6 +7,7 @@ export const noRuntimeExceptionsRating: PerBuildRating = {
   description: "Ensures the app doesn't have runtime exceptions.",
   kind: RatingKind.PER_BUILD,
   category: RatingCategory.HIGH_IMPACT,
+  groupingLabels: ['functionality', 'runability'],
   scoreReduction: '50%',
   id: 'common-no-runtime-errors',
   rate: ({buildResult, serveResult}) => ({

--- a/runner/ratings/built-in-ratings/safety-web-rating.ts
+++ b/runner/ratings/built-in-ratings/safety-web-rating.ts
@@ -8,6 +8,7 @@ export const safetyWebRating: PerBuildRating = {
   name: 'SafetyWeb Violations',
   description: 'Checks for TrustedTypes and CSP incompatible coding patterns.',
   category: RatingCategory.HIGH_IMPACT,
+  groupingLabels: ['security'],
   id: 'safety-web',
   scoreReduction: '50%',
   rate: ({buildResult}) => {

--- a/runner/ratings/built-in-ratings/security-ratings.ts
+++ b/runner/ratings/built-in-ratings/security-ratings.ts
@@ -38,6 +38,7 @@ export const cspViolationsRating: PerBuildRating = {
   description: 'Checks for Content Security Policy violations, excluding Trusted Types.',
   id: 'csp-violations',
   category: RatingCategory.HIGH_IMPACT,
+  groupingLabels: ['security'],
   scoreReduction: '50%',
   rate: ({serveResult}) => {
     if (!serveResult?.cspViolations) {
@@ -78,6 +79,7 @@ export const trustedTypesViolationsRating: PerBuildRating = {
   description: 'Checks for Trusted Types violations specifically.',
   id: 'trusted-types-violations',
   category: RatingCategory.HIGH_IMPACT,
+  groupingLabels: ['security'],
   scoreReduction: '50%',
   rate: ({serveResult}) => {
     if (!serveResult?.cspViolations) {

--- a/runner/ratings/built-in-ratings/successful-build-rating.ts
+++ b/runner/ratings/built-in-ratings/successful-build-rating.ts
@@ -8,6 +8,7 @@ export const successfulBuildRating: PerBuildRating = {
   id: 'common-successful-build',
   kind: RatingKind.PER_BUILD,
   category: RatingCategory.HIGH_IMPACT,
+  groupingLabels: ['functionality'],
   scoreReduction: '50%',
   // Reduce the amount of points in case we've built the code with a few repair attempts.
   rate: ({buildResult, repairAttempts}) => ({

--- a/runner/ratings/built-in-ratings/successful-tests-rating.ts
+++ b/runner/ratings/built-in-ratings/successful-tests-rating.ts
@@ -7,6 +7,7 @@ export const successfulTestsRating: PerBuildRating = {
   id: 'common-successful-tests',
   kind: RatingKind.PER_BUILD,
   category: RatingCategory.MEDIUM_IMPACT,
+  groupingLabels: ['functionality'],
   scoreReduction: '30%',
   // Reduce the amount of points in case we've had test repair attempts.
   rate: ({testResult, testRepairAttempts}) => {

--- a/runner/ratings/built-in-ratings/sufficient-code-size-rating.ts
+++ b/runner/ratings/built-in-ratings/sufficient-code-size-rating.ts
@@ -10,6 +10,7 @@ export const sufficientCodeSizeRating: PerFileRating = {
   name: 'Sufficient Code Size (over 50b)',
   description: 'Ensures the generated code is not trivially small (e.g. < 50b).',
   category: RatingCategory.HIGH_IMPACT,
+  groupingLabels: ['functionality'],
   id: 'common-generated-code-size',
   scoreReduction: '30%',
   kind: RatingKind.PER_FILE,

--- a/runner/ratings/built-in-ratings/sufficient-generated-files-rating.ts
+++ b/runner/ratings/built-in-ratings/sufficient-generated-files-rating.ts
@@ -5,6 +5,7 @@ export const sufficientGeneratedFilesRating: PerBuildRating = {
   name: 'Sufficient number of generated files',
   description: 'Ensures that the LLM produced at least one file.',
   category: RatingCategory.HIGH_IMPACT,
+  groupingLabels: ['functionality'],
   id: 'common-generated-file-count',
   scoreReduction: '100%',
   kind: RatingKind.PER_BUILD,

--- a/runner/ratings/built-in-ratings/user-journeys-rating.ts
+++ b/runner/ratings/built-in-ratings/user-journeys-rating.ts
@@ -7,6 +7,7 @@ export const userJourneysRating: PerBuildRating = {
   description: 'Ensures that all User Journeys are working in the generated app',
   kind: RatingKind.PER_BUILD,
   category: RatingCategory.MEDIUM_IMPACT,
+  groupingLabels: ['functionality', 'runability', 'interaction-testing'],
   scoreReduction: '30%',
   rate: ({serveResult}) => {
     if (serveResult === null || serveResult.userJourneyAgentOutput === null) {

--- a/runner/ratings/built-in-ratings/valid-css-rating.ts
+++ b/runner/ratings/built-in-ratings/valid-css-rating.ts
@@ -11,6 +11,7 @@ export const validCssRating: PerFileRating = {
   name: 'Valid CSS',
   description: 'Ensures that the generated CSS code is valid',
   category: RatingCategory.MEDIUM_IMPACT,
+  groupingLabels: ['functionality', 'styling'],
   scoreReduction: '20%',
   kind: RatingKind.PER_FILE,
   id: 'common-valid-css',

--- a/runner/ratings/built-in-ratings/visual-appearance-rating.ts
+++ b/runner/ratings/built-in-ratings/visual-appearance-rating.ts
@@ -9,6 +9,7 @@ export const visualAppearanceRating: LLMBasedRating = {
   name: 'UI & Visual appearance (LLM-Rated)',
   description: 'Rates the app based on its visuals (UI visuals and feature completeness).',
   category: RatingCategory.MEDIUM_IMPACT,
+  groupingLabels: ['llm-judge', 'visual-appearance', 'runability'],
   scoreReduction: '30%',
   id: 'common-autorater-visuals',
   rate: async ctx => {

--- a/runner/ratings/rate-code.ts
+++ b/runner/ratings/rate-code.ts
@@ -331,6 +331,7 @@ function getIndividualAssessment(
     scoreReduction: rating.scoreReduction,
     successPercentage: rateResult,
     category: rating.category,
+    groupingLabels: rating.groupingLabels,
     message,
   };
 }
@@ -342,6 +343,7 @@ function getSkippedAssessment(rating: Rating, message: string): SkippedIndividua
     description: rating.description,
     id: rating.id,
     category: rating.category,
+    groupingLabels: rating.groupingLabels,
     message,
   };
 }

--- a/runner/ratings/rating-types.ts
+++ b/runner/ratings/rating-types.ts
@@ -57,6 +57,7 @@ const ratingSchemaCommonFields = {
   name: z.string(),
   description: z.string(),
   id: z.string(),
+  groupingLabels: z.array(z.string()).optional(),
 } as const;
 
 const perBuildRatingSchema = z

--- a/runner/shared-interfaces.ts
+++ b/runner/shared-interfaces.ts
@@ -206,6 +206,8 @@ export interface IndividualAssessment {
   message: string;
   /** LLM usage for running the assessment. */
   usage?: Usage;
+  /** Labels for this check. Useful for custom grouping of e.g. "best practice" checks. */
+  groupingLabels?: string[];
 }
 
 export interface SkippedIndividualAssessment {
@@ -220,6 +222,8 @@ export interface SkippedIndividualAssessment {
   category: RatingCategory;
   /** A message explaining why the check was skipped. */
   message: string;
+  /** Labels for this check. Useful for custom grouping of e.g. "best practice" checks. */
+  groupingLabels?: string[];
 }
 
 /**


### PR DESCRIPTION
* Supports adding grouping labels to ratings. The labels can be used to identify similar-related ratings— but nothing in the UI or UI JSON is doing the grouping yet. The labels are exposed to the individual checks though.