### PR TITLE
refactor: rename `runability` to `running-app-checks`

### DIFF
--- a/runner/ratings/built-in-ratings/no-runtime-errors-rating.ts
+++ b/runner/ratings/built-in-ratings/no-runtime-errors-rating.ts
@@ -7,7 +7,7 @@ export const noRuntimeExceptionsRating: PerBuildRating = {
   description: "Ensures the app doesn't have runtime exceptions.",
   kind: RatingKind.PER_BUILD,
   category: RatingCategory.HIGH_IMPACT,
-  groupingLabels: ['functionality', 'runability'],
+  groupingLabels: ['functionality', 'running-app-checks'],
   scoreReduction: '50%',
   id: 'common-no-runtime-errors',
   rate: ({buildResult, serveResult}) => ({

--- a/runner/ratings/built-in-ratings/user-journeys-rating.ts
+++ b/runner/ratings/built-in-ratings/user-journeys-rating.ts
@@ -7,7 +7,7 @@ export const userJourneysRating: PerBuildRating = {
   description: 'Ensures that all User Journeys are working in the generated app',
   kind: RatingKind.PER_BUILD,
   category: RatingCategory.MEDIUM_IMPACT,
-  groupingLabels: ['functionality', 'runability', 'interaction-testing'],
+  groupingLabels: ['functionality', 'running-app-checks', 'interaction-testing'],
   scoreReduction: '30%',
   rate: ({serveResult}) => {
     if (serveResult === null || serveResult.userJourneyAgentOutput === null) {

--- a/runner/ratings/built-in-ratings/visual-appearance-rating.ts
+++ b/runner/ratings/built-in-ratings/visual-appearance-rating.ts
@@ -9,7 +9,7 @@ export const visualAppearanceRating: LLMBasedRating = {
   name: 'UI & Visual appearance (LLM-Rated)',
   description: 'Rates the app based on its visuals (UI visuals and feature completeness).',
   category: RatingCategory.MEDIUM_IMPACT,
-  groupingLabels: ['llm-judge', 'visual-appearance', 'runability'],
+  groupingLabels: ['llm-judge', 'visual-appearance', 'running-app-checks'],
   scoreReduction: '30%',
   id: 'common-autorater-visuals',
   rate: async ctx => {


### PR DESCRIPTION
Renames the label as it's currently a bit confusing/ambiguous when shown next to the `functionality` "rubric".