### PR TITLE
fix: capture error stack for codegen runtime errors

### DIFF
--- a/runner/orchestration/codegen.ts
+++ b/runner/orchestration/codegen.ts
@@ -69,7 +69,7 @@ export async function generateCodeWithAI(
     success = false;
     reasoning = '';
     toolLogs = [];
-    errors.push(error + '');
+    errors.push(`${error}${error instanceof Error ? `\nStack: ${error.stack}` : ''}`);
   }
 
   return {


### PR DESCRIPTION
Whenever Genkit, or other runners throw an error during LLM response generation, we don't capture the stack. This makes debugging really hard.