### PR TITLE
feat: support AI SDK runner and Claude 4.1 Opus & Sonnet 4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You can customize the `web-codegen-scorer eval` script with the following flags:
     - Example: `web-codegen-scorer eval --model=gemini-2.5-flash --autorater-model=gemini-2.5-flash --env=<config path>`
 
 - `--runner=<name>`: Specifies the runner to use to execute the eval. Supported runners are
-  `genkit` (default), `gemini-cli`, `claude-code` or `codex`.
+  `genkit` (default), `ai-sdk`, `gemini-cli`, `claude-code` or `codex`.
 
 - `--local`: Runs the script in local mode for the initial code generation request. Instead of
   calling the LLM, it will attempt to read the initial code from a corresponding file in the

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "wcs": "./runner/bin/cli.js"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^2.0.45",
     "@anthropic-ai/sdk": "^0.68.0",
     "@axe-core/puppeteer": "^4.10.2",
     "@genkit-ai/compat-oai": "1.23.0",
@@ -63,6 +64,7 @@
     "@types/cli-progress": "^3.11.6",
     "@types/node": "^24.2.0",
     "@types/yargs": "^17.0.33",
+    "ai": "^5.0.95",
     "axe-core": "^4.10.3",
     "boxen": "^8.0.1",
     "chalk": "^5.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^2.0.45
+        version: 2.0.45(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.68.0
         version: 0.68.0(zod@3.25.76)
@@ -44,6 +47,9 @@ importers:
       '@types/yargs':
         specifier: ^17.0.33
         version: 17.0.33
+      ai:
+        specifier: ^5.0.95
+        version: 5.0.95(zod@3.25.76)
       axe-core:
         specifier: ^4.10.3
         version: 4.11.0
@@ -240,6 +246,28 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@ai-sdk/anthropic@2.0.45':
+    resolution: {integrity: sha512-Ipv62vavDCmrV/oE/lXehL9FzwQuZOnnlhPEftWizx464Wb6lvnBTJx8uhmEYruFSzOWTI95Z33ncZ4tA8E6RQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@2.0.11':
+    resolution: {integrity: sha512-B0Vt2Xv88Lo9rg861Oyzq/SdTmT4LiqdjkpOxpSPpNk8Ih5TXTgyDAsV/qW14N6asPdK1YI5PosFLnVzfK5LrA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@3.0.17':
+    resolution: {integrity: sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@2.0.0':
+    resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
+    engines: {node: '>=18'}
 
   '@alcalzone/ansi-tokenize@0.2.2':
     resolution: {integrity: sha512-mkOh+Wwawzuf5wa30bvc4nA+Qb6DIrGWgBhRR/Pw4T9nsgYait8izvXkNyU78D6Wcu3Z+KUdwCmLCxlWjEotYA==}
@@ -3468,6 +3496,10 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@vercel/oidc@3.0.3':
+    resolution: {integrity: sha512-yNEQvPcVrK9sIe637+I0jD6leluPxzwJKx/Haw6F4H77CdDsszUn5V3o96LPziXkSNE2B83+Z3mjqGKBK/R6Gg==}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-basic-ssl@2.1.0':
     resolution: {integrity: sha512-dOxxrhgyDIEUADhb/8OlV9JIqYLgos03YorAueTIeOUskLJSEsfwCByjbu98ctXitUN3znXKp0bYD/WHSudCeA==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -3522,6 +3554,12 @@ packages:
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
+
+  ai@5.0.95:
+    resolution: {integrity: sha512-dsvFdYMeGP08zuUQkhKO1UMMXMCb+nro9ZmDdwaAkkTlCGkP3u1S+xaRUDNayu/c0KVkiTtfEroPG//U+kvXzg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -7337,6 +7375,30 @@ packages:
     hasBin: true
 
 snapshots:
+
+  '@ai-sdk/anthropic@2.0.45(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.17(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/gateway@2.0.11(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.17(zod@3.25.76)
+      '@vercel/oidc': 3.0.3
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@3.0.17(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@standard-schema/spec': 1.0.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.76
+
+  '@ai-sdk/provider@2.0.0':
+    dependencies:
+      json-schema: 0.4.0
 
   '@alcalzone/ansi-tokenize@0.2.2':
     dependencies:
@@ -11203,6 +11265,8 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vercel/oidc@3.0.3': {}
+
   '@vitejs/plugin-basic-ssl@2.1.0(vite@7.1.7(@types/node@24.8.1)(sass@1.93.1)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       vite: 7.1.7(@types/node@24.8.1)(sass@1.93.1)(tsx@4.20.6)(yaml@2.8.1)
@@ -11248,6 +11312,14 @@ snapshots:
   agentkeepalive@4.6.0:
     dependencies:
       humanize-ms: 1.2.1
+
+  ai@5.0.95(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/gateway': 2.0.11(zod@3.25.76)
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.17(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      zod: 3.25.76
 
   ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:

--- a/runner/codegen/ai-sdk-runner.ts
+++ b/runner/codegen/ai-sdk-runner.ts
@@ -1,0 +1,208 @@
+import {
+  LlmRunner,
+  LocalLlmConstrainedOutputGenerateRequestOptions,
+  LocalLlmConstrainedOutputGenerateResponse,
+  LocalLlmGenerateFilesRequestOptions,
+  LocalLlmGenerateFilesResponse,
+  LocalLlmGenerateTextRequestOptions,
+  LocalLlmGenerateTextResponse,
+  PromptDataMessage,
+} from './llm-runner.js';
+import {
+  FilePart,
+  generateObject,
+  generateText,
+  LanguageModel,
+  ModelMessage,
+  SystemModelMessage,
+  TextPart,
+} from 'ai';
+import {anthropic, AnthropicProviderOptions} from '@ai-sdk/anthropic';
+import z from 'zod';
+import {callWithTimeout} from '../utils/timeout.js';
+import {combineAbortSignals} from '../utils/abort-signal.js';
+
+const SUPPORTED_MODELS = [
+  'claude-opus-4.1-no-thinking',
+  'claude-opus-4.1-with-thinking',
+  'claude-sonnet-4.5-no-thinking',
+  'claude-sonnet-4.5-with-thinking',
+] as const;
+
+// Increased to a very high value as we rely on an actual timeout
+// that aborts stuck LLM requests. WCS is targeting stability here;
+// even if it involves many exponential backoff-waiting.
+const DEFAULT_MAX_RETRIES = 100000;
+
+export class AiSDKRunner implements LlmRunner {
+  displayName = 'AI SDK';
+  id = 'ai-sdk';
+  hasBuiltInRepairLoop = true;
+
+  async generateText(
+    options: LocalLlmGenerateTextRequestOptions,
+  ): Promise<LocalLlmGenerateTextResponse> {
+    const response = await this._wrapRequestWithTimeoutAndRateLimiting(options, async abortSignal =>
+      generateText({
+        ...(await this._getAiSdkModelOptions(options)),
+        abortSignal: abortSignal,
+        messages: this._convertRequestToMessagesList(options),
+        maxRetries: DEFAULT_MAX_RETRIES,
+      }),
+    );
+
+    return {
+      reasoning: response.reasoningText ?? '',
+      text: response.text,
+      usage: response.usage,
+      // TODO: Consider supporting `toolLogs` and MCP here.
+    };
+  }
+
+  async generateConstrained<T extends z.ZodTypeAny = z.ZodTypeAny>(
+    options: LocalLlmConstrainedOutputGenerateRequestOptions<T>,
+  ): Promise<LocalLlmConstrainedOutputGenerateResponse<T>> {
+    const response = await this._wrapRequestWithTimeoutAndRateLimiting(options, async abortSignal =>
+      generateObject({
+        ...(await this._getAiSdkModelOptions(options)),
+        messages: this._convertRequestToMessagesList(options),
+        schema: options.schema,
+        abortSignal: abortSignal,
+        maxRetries: DEFAULT_MAX_RETRIES,
+      }),
+    );
+
+    return {
+      reasoning: response.reasoning ?? '',
+      output: response.object,
+      usage: response.usage,
+      // TODO: Consider supporting `toolLogs` and MCP here.
+    };
+  }
+
+  async generateFiles(
+    options: LocalLlmGenerateFilesRequestOptions,
+  ): Promise<LocalLlmGenerateFilesResponse> {
+    const response = await this.generateConstrained({
+      ...options,
+      prompt: options.context.executablePrompt,
+      systemPrompt: options.context.systemInstructions,
+      schema: z.object({
+        outputFiles: z.array(
+          z.object({
+            filePath: z.string().describe('Name of the file that is being changed'),
+            code: z.string().describe('New code of the file'),
+          }),
+        ),
+      }),
+    });
+
+    return {
+      files: response.output?.outputFiles ?? [],
+      reasoning: response.reasoning,
+      usage: response.usage,
+      // TODO: Consider supporting `toolLogs` and MCP here.
+    };
+  }
+
+  getSupportedModels(): string[] {
+    return [...SUPPORTED_MODELS];
+  }
+
+  async dispose(): Promise<void> {}
+
+  private async _wrapRequestWithTimeoutAndRateLimiting<T>(
+    request: LocalLlmGenerateTextRequestOptions | LocalLlmConstrainedOutputGenerateRequestOptions,
+    fn: (abortSignal: AbortSignal) => Promise<T>,
+  ): Promise<T> {
+    // TODO: Check if rate-limiting is actually necessary here. AI SDK
+    // seems to do retrying on its own.
+
+    if (request.timeout === undefined) {
+      return await fn(request.abortSignal);
+    }
+    return callWithTimeout(
+      request.timeout.description,
+      abortSignal => fn(combineAbortSignals(abortSignal, request.abortSignal)),
+      request.timeout.durationInMins,
+    );
+  }
+
+  private async _getAiSdkModelOptions(
+    request: LocalLlmGenerateTextRequestOptions,
+  ): Promise<{model: LanguageModel; providerOptions: {}}> {
+    switch (request.model) {
+      case 'claude-opus-4.1-no-thinking':
+      case 'claude-opus-4.1-with-thinking': {
+        const thinkingEnabled = request.model.endsWith('with-thinking');
+        return {
+          model: anthropic('claude-opus-4-1'),
+          providerOptions: {
+            sendReasoning: thinkingEnabled,
+            thinking: {type: thinkingEnabled ? 'enabled' : 'disabled'},
+          } satisfies AnthropicProviderOptions,
+        };
+      }
+      case 'claude-sonnet-4.5-no-thinking':
+      case 'claude-sonnet-4.5-with-thinking': {
+        const thinkingEnabled = request.model.endsWith('with-thinking');
+        return {
+          model: anthropic('claude-sonnet-4-5'),
+          providerOptions: {
+            sendReasoning: true,
+            thinking: {type: 'enabled'},
+          } satisfies AnthropicProviderOptions,
+        };
+      }
+      default:
+        throw new Error(`Unexpected model in AI SDK runner: ${request.model}.`);
+    }
+  }
+
+  private _convertRequestToMessagesList(
+    request: LocalLlmConstrainedOutputGenerateRequestOptions | LocalLlmGenerateTextRequestOptions,
+  ): ModelMessage[] {
+    return [
+      // System prompt message.
+      ...(request.systemPrompt !== undefined
+        ? [
+            {
+              role: 'system',
+              content: request.systemPrompt,
+            } satisfies SystemModelMessage,
+          ]
+        : []),
+      // Optional additional messages
+      ...this._toAiSDKMessage(request.messages ?? []),
+      // The main message.
+      {role: 'user', content: [{type: 'text', text: request.prompt}]},
+    ];
+  }
+
+  private _toAiSDKMessage(messages: PromptDataMessage[]): ModelMessage[] {
+    const result: ModelMessage[] = [];
+
+    for (const message of messages) {
+      if (message.role === 'model') {
+        result.push({
+          role: 'assistant',
+          content: message.content.map(c =>
+            'media' in c
+              ? ({type: 'file', data: c.media.url, mediaType: 'image/png'} satisfies FilePart)
+              : ({type: 'text', text: c.text} satisfies TextPart),
+          ),
+        });
+      } else if (message.role === 'user') {
+        result.push({
+          role: 'user',
+          content: message.content.map(c =>
+            'media' in c
+              ? ({type: 'file', data: c.media.url, mediaType: 'image/png'} satisfies FilePart)
+              : ({type: 'text', text: c.text} satisfies TextPart),
+          ),
+        });
+      }
+    }
+    return result;
+  }
+}

--- a/runner/codegen/runner-creation.ts
+++ b/runner/codegen/runner-creation.ts
@@ -4,9 +4,11 @@ import type {ClaudeCodeRunner} from './claude-code-runner.js';
 import type {GenkitRunner} from './genkit/genkit-runner.js';
 import type {CodexRunner} from './codex-runner.js';
 import type {NoopUnimplementedRunner} from './noop-unimplemented-runner.js';
+import {AiSDKRunner} from './ai-sdk-runner.js';
 
 interface AvailableRunners {
   genkit: GenkitRunner;
+  'ai-sdk': AiSDKRunner;
   'gemini-cli': GeminiCliRunner;
   'claude-code': ClaudeCodeRunner;
   'codex': CodexRunner;
@@ -27,6 +29,8 @@ export async function getRunnerByName<T extends RunnerName>(name: T): Promise<Av
       return import('./genkit/genkit-runner.js').then(
         m => new m.GenkitRunner() as AvailableRunners[T],
       );
+    case 'ai-sdk':
+      return import('./ai-sdk-runner.js').then(m => new m.AiSDKRunner() as AvailableRunners[T]);
     case 'gemini-cli':
       return import('./gemini-cli-runner.js').then(
         m => new m.GeminiCliRunner() as AvailableRunners[T],

--- a/runner/eval-cli.ts
+++ b/runner/eval-cli.ts
@@ -61,7 +61,7 @@ function builder(argv: Argv): Argv<Options> {
       .option('runner', {
         type: 'string',
         default: 'genkit' as const,
-        choices: ['genkit', 'gemini-cli', 'claude-code', 'codex'] as RunnerName[],
+        choices: ['genkit', 'ai-sdk', 'gemini-cli', 'claude-code', 'codex'] as RunnerName[],
         description: 'Runner to use to execute the eval',
       })
       .option('local', {


### PR DESCRIPTION
The Genkit runner and community libraries are seemingly falling behind here (with regards to Claude latest models), as it's not possible to trivially enable Opus 4.1 or Sonnet 4.5.

This commit introduces the AI SDK runner and adds support for the latest Claude models that way. Notably AI SDK has a pretty complete documentation and more discoverable types (by avoiding Zod complexity). Also it does retries automatically and implements exponential backoff!