### PR TITLE
refactor: adjust grouping labels for more insightful rubric analysis

### DIFF
--- a/runner/ratings/built-in-ratings/code-quality-rating.ts
+++ b/runner/ratings/built-in-ratings/code-quality-rating.ts
@@ -7,7 +7,7 @@ export const codeQualityRating: LLMBasedRating = {
   name: 'Code Quality (LLM-rated)',
   description: `Rates the app's source code via LLM`,
   category: RatingCategory.MEDIUM_IMPACT,
-  groupingLabels: ['llm-judge'],
+  groupingLabels: ['llm-judge', 'llm-rated-code-quality'],
   id: 'common-autorater-code-quality',
   scoreReduction: '30%',
   rate: async ctx => {

--- a/runner/ratings/built-in-ratings/no-runtime-errors-rating.ts
+++ b/runner/ratings/built-in-ratings/no-runtime-errors-rating.ts
@@ -7,7 +7,7 @@ export const noRuntimeExceptionsRating: PerBuildRating = {
   description: "Ensures the app doesn't have runtime exceptions.",
   kind: RatingKind.PER_BUILD,
   category: RatingCategory.HIGH_IMPACT,
-  groupingLabels: ['functionality', 'running-app-checks'],
+  groupingLabels: ['functionality', 'runtime-errors', 'running-app-checks'],
   scoreReduction: '50%',
   id: 'common-no-runtime-errors',
   rate: ({buildResult, serveResult}) => ({

--- a/runner/ratings/built-in-ratings/successful-build-rating.ts
+++ b/runner/ratings/built-in-ratings/successful-build-rating.ts
@@ -8,7 +8,7 @@ export const successfulBuildRating: PerBuildRating = {
   id: 'common-successful-build',
   kind: RatingKind.PER_BUILD,
   category: RatingCategory.HIGH_IMPACT,
-  groupingLabels: ['functionality'],
+  groupingLabels: ['functionality', 'build-success'],
   scoreReduction: '50%',
   // Reduce the amount of points in case we've built the code with a few repair attempts.
   rate: ({buildResult, repairAttempts}) => ({

--- a/runner/ratings/built-in-ratings/successful-tests-rating.ts
+++ b/runner/ratings/built-in-ratings/successful-tests-rating.ts
@@ -7,7 +7,7 @@ export const successfulTestsRating: PerBuildRating = {
   id: 'common-successful-tests',
   kind: RatingKind.PER_BUILD,
   category: RatingCategory.MEDIUM_IMPACT,
-  groupingLabels: ['functionality'],
+  groupingLabels: ['functionality', 'project-tests'],
   scoreReduction: '30%',
   // Reduce the amount of points in case we've had test repair attempts.
   rate: ({testResult, testRepairAttempts}) => {

--- a/runner/ratings/built-in-ratings/sufficient-code-size-rating.ts
+++ b/runner/ratings/built-in-ratings/sufficient-code-size-rating.ts
@@ -10,7 +10,6 @@ export const sufficientCodeSizeRating: PerFileRating = {
   name: 'Sufficient Code Size (over 50b)',
   description: 'Ensures the generated code is not trivially small (e.g. < 50b).',
   category: RatingCategory.HIGH_IMPACT,
-  groupingLabels: ['functionality'],
   id: 'common-generated-code-size',
   scoreReduction: '30%',
   kind: RatingKind.PER_FILE,

--- a/runner/ratings/built-in-ratings/sufficient-generated-files-rating.ts
+++ b/runner/ratings/built-in-ratings/sufficient-generated-files-rating.ts
@@ -5,7 +5,6 @@ export const sufficientGeneratedFilesRating: PerBuildRating = {
   name: 'Sufficient number of generated files',
   description: 'Ensures that the LLM produced at least one file.',
   category: RatingCategory.HIGH_IMPACT,
-  groupingLabels: ['functionality'],
   id: 'common-generated-file-count',
   scoreReduction: '100%',
   kind: RatingKind.PER_BUILD,

--- a/runner/ratings/built-in-ratings/user-journeys-rating.ts
+++ b/runner/ratings/built-in-ratings/user-journeys-rating.ts
@@ -13,7 +13,7 @@ export const userJourneysRating: PerBuildRating = {
     if (serveResult === null || serveResult.userJourneyAgentOutput === null) {
       return {
         state: RatingState.SKIPPED,
-        message: 'Was not enabled for this run',
+        message: 'Not enabled for this run.',
       };
     }
 

--- a/runner/ratings/built-in-ratings/valid-css-rating.ts
+++ b/runner/ratings/built-in-ratings/valid-css-rating.ts
@@ -11,7 +11,7 @@ export const validCssRating: PerFileRating = {
   name: 'Valid CSS',
   description: 'Ensures that the generated CSS code is valid',
   category: RatingCategory.MEDIUM_IMPACT,
-  groupingLabels: ['functionality', 'styling'],
+  groupingLabels: ['functionality', 'styling', 'css-validity'],
   scoreReduction: '20%',
   kind: RatingKind.PER_FILE,
   id: 'common-valid-css',

--- a/runner/ratings/built-in-ratings/visual-appearance-rating.ts
+++ b/runner/ratings/built-in-ratings/visual-appearance-rating.ts
@@ -9,7 +9,7 @@ export const visualAppearanceRating: LLMBasedRating = {
   name: 'UI & Visual appearance (LLM-Rated)',
   description: 'Rates the app based on its visuals (UI visuals and feature completeness).',
   category: RatingCategory.MEDIUM_IMPACT,
-  groupingLabels: ['llm-judge', 'visual-appearance', 'running-app-checks'],
+  groupingLabels: ['llm-judge', 'llm-rated-visual-appearance', 'running-app-checks'],
   scoreReduction: '30%',
   id: 'common-autorater-visuals',
   rate: async ctx => {


### PR DESCRIPTION
* Functionality is pretty broad. We need better insight into more focused rubrics. Obviously the individual checks could be pulled directly- but adding the labels is trivial and useful in general.
* Adds more focused labels where useful.
* Removes sufficient code checks from the functionality rubric as they are highly "impactful from scoring" but not necessarily represent actual functionality. E.g. if there is always at least a file generated, it would significantly drag up the score because it's a 100% high impact category. Maybe in the future these ratings need to be adjusted to actually represent "functionality" better. If build is failing— they could return 0% success, or just be "skipped".