### PR TITLE
refactor: rename build sucess rubric

### DIFF
--- a/runner/ratings/built-in-ratings/successful-build-rating.ts
+++ b/runner/ratings/built-in-ratings/successful-build-rating.ts
@@ -8,7 +8,7 @@ export const successfulBuildRating: PerBuildRating = {
   id: 'common-successful-build',
   kind: RatingKind.PER_BUILD,
   category: RatingCategory.HIGH_IMPACT,
-  groupingLabels: ['functionality', 'build-success'],
+  groupingLabels: ['functionality', 'build-failures'],
   scoreReduction: '50%',
   // Reduce the amount of points in case we've built the code with a few repair attempts.
   rate: ({buildResult, repairAttempts}) => ({


### PR DESCRIPTION
Similar to `runtime-errors` we switch the rubric group. This makes the "percentages" more easy to reason about.