### PR TITLE
feat: support retrying timed out evaluations

### DIFF
--- a/runner/configuration/constants.ts
+++ b/runner/configuration/constants.ts
@@ -33,6 +33,9 @@ export const DEFAULT_MAX_BUILD_REPAIR_ATTEMPTS = 1;
  */
 export const DEFAULT_MAX_TEST_REPAIR_ATTEMPTS = 0;
 
+/** Default number of retries when a prompt evaluation timed out. */
+export const DEFAULT_PROMPT_TIMEOUT_RETRIES = 1;
+
 /** Name of the folder where we store all generated reports */
 export const REPORTS_ROOT_DIR = join(rootDir, 'reports');
 

--- a/runner/eval-cli.ts
+++ b/runner/eval-cli.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_MAX_BUILD_REPAIR_ATTEMPTS,
   DEFAULT_MAX_TEST_REPAIR_ATTEMPTS,
   DEFAULT_MODEL_NAME,
+  DEFAULT_PROMPT_TIMEOUT_RETRIES,
 } from './configuration/constants.js';
 import {generateCodeAndAssess} from './orchestration/generate.js';
 import {logReportToConsole, writeReportToDisk} from './reporting/report-logging.js';
@@ -42,6 +43,7 @@ interface Options {
   skipLighthouse?: boolean;
   maxTestRepairAttempts?: number;
   maxBuildRepairAttempts?: number;
+  promptTimeoutRetries?: number;
 }
 
 function builder(argv: Argv): Argv<Options> {
@@ -168,6 +170,12 @@ function builder(argv: Argv): Argv<Options> {
         description:
           'Number of repair attempts for discovered test failures (including a11y violations and ones from testCommand)',
       })
+      .option('prompt-timeout-retries', {
+        type: 'number',
+        default: DEFAULT_PROMPT_TIMEOUT_RETRIES,
+        description:
+          'Maximum number of times to retry a prompt evaluation after it fails due to a timeout.',
+      })
       .strict()
       .version(false)
       .help()
@@ -221,6 +229,7 @@ async function handler(cliArgs: Arguments<Options>): Promise<void> {
       skipLighthouse: cliArgs.skipLighthouse,
       maxBuildRepairAttempts: cliArgs.maxBuildRepairAttempts,
       maxTestRepairAttempts: cliArgs.maxTestRepairAttempts,
+      promptTimeoutRetries: cliArgs.promptTimeoutRetries,
       abortSignal: abortCtrl.signal,
     });
 

--- a/runner/shared-interfaces.ts
+++ b/runner/shared-interfaces.ts
@@ -30,6 +30,7 @@ export interface AssessmentConfig {
   skipLighthouse?: boolean;
   maxTestRepairAttempts?: number;
   maxBuildRepairAttempts?: number;
+  promptTimeoutRetries?: number;
   abortSignal?: AbortSignal;
 }
 


### PR DESCRIPTION
We should not flaw/skip results due to timeouts caused by e.g. stuck building or stuck serving.