### PR TITLE
fix: unexpected code path triggered due to incorrect retry check

### DIFF
--- a/runner/orchestration/generate.ts
+++ b/runner/orchestration/generate.ts
@@ -189,7 +189,7 @@ export async function generateCodeAndAssess(options: AssessmentConfig): Promise<
             try {
               return await evaluate();
             } catch (e: unknown) {
-              if (e instanceof TimeoutError && attemptIdx < maxAttempts) {
+              if (e instanceof TimeoutError && attemptIdx < maxAttempts - 1) {
                 continue;
               }
 


### PR DESCRIPTION
We should not allow for an extra attempt that would try to re-enter the for loop but would not satisfy the `< maxAttempts` condition.