### PR TITLE
refactor: rename grouping labels to avoid further confusion

### DIFF
--- a/runner/ratings/built-in-ratings/no-runtime-errors-rating.ts
+++ b/runner/ratings/built-in-ratings/no-runtime-errors-rating.ts
@@ -7,7 +7,7 @@ export const noRuntimeExceptionsRating: PerBuildRating = {
   description: "Ensures the app doesn't have runtime exceptions.",
   kind: RatingKind.PER_BUILD,
   category: RatingCategory.HIGH_IMPACT,
-  groupingLabels: ['functionality', 'runtime-errors', 'running-app-checks'],
+  groupingLabels: ['functionality', 'no-runtime-errors', 'running-app-checks'],
   scoreReduction: '50%',
   id: 'common-no-runtime-errors',
   rate: ({buildResult, serveResult}) => ({

--- a/runner/ratings/built-in-ratings/successful-build-rating.ts
+++ b/runner/ratings/built-in-ratings/successful-build-rating.ts
@@ -8,7 +8,7 @@ export const successfulBuildRating: PerBuildRating = {
   id: 'common-successful-build',
   kind: RatingKind.PER_BUILD,
   category: RatingCategory.HIGH_IMPACT,
-  groupingLabels: ['functionality', 'build-failures'],
+  groupingLabels: ['functionality', 'successful-builds'],
   scoreReduction: '50%',
   // Reduce the amount of points in case we've built the code with a few repair attempts.
   rate: ({buildResult, repairAttempts}) => ({


### PR DESCRIPTION
The percentages of rubrics can be still misleading. It was seemingly a mistake to rename `successful-builds` to `build-failures` as the current scores of the check are 100% for "passing the rating" and "0%" for "failing the rating".

NOTE (for remembering): Even though some runs were with `build-failures`, the meaning is the same as of this commit.