### PR TITLE
fix: do not silently fail puppeteer testing

### DIFF
--- a/runner/workers/serve-testing/puppeteer.ts
+++ b/runner/workers/serve-testing/puppeteer.ts
@@ -28,149 +28,142 @@ export async function runAppInPuppeteer(
   let screenshotBase64Data: string | undefined;
   let axeViolations: AxeResult[] | undefined;
   let lighthouseResult: LighthouseResult | undefined;
+  let unexpectedErrorMessage: string | undefined;
 
-  try {
-    const browser = await puppeteer.launch({
-      headless: true,
-      args: [
-        '--no-sandbox',
-        '--disable-setuid-sandbox',
-        '--disable-dev-shm-usage',
-        '--disable-gpu',
-      ],
-    });
-    const page = await browser.newPage();
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage', '--disable-gpu'],
+  });
+  const page = await browser.newPage();
 
-    page.on('console', async message => {
-      if (message.type() !== 'error') return;
+  page.on('console', async message => {
+    if (message.type() !== 'error') return;
 
-      if (!message.text().includes('JSHandle@error')) {
-        progressLog(
-          'error',
-          `Runtime Error: ${message.type().substring(0, 3).toUpperCase()} ${message.text()}`,
-        );
+    if (!message.text().includes('JSHandle@error')) {
+      progressLog(
+        'error',
+        `Runtime Error: ${message.type().substring(0, 3).toUpperCase()} ${message.text()}`,
+      );
+      return;
+    }
+    const messages = await Promise.all(
+      message.args().map(async arg => {
+        const [message, stack] = await Promise.all([
+          arg.getProperty('message'),
+          arg.getProperty('stack'),
+        ]);
+
+        let result = '';
+        if (message) {
+          result += message;
+        }
+        if (stack) {
+          result += (result.length ? '\n\n' : '') + stack;
+        }
+        return result;
+      }),
+    );
+    runtimeErrors.push(messages.filter(Boolean).join('\n'));
+  });
+
+  page.on('pageerror', error => {
+    progressLog('error', 'Page error', error.message);
+    runtimeErrors.push(error.toString());
+  });
+
+  await page.setViewport({width: 1280, height: 720});
+
+  // Set up auto-CSP handling if enabled for the environment.
+  if (enableAutoCsp) {
+    const autoCsp = new AutoCsp();
+    await autoCsp.connectToDevTools(page);
+    await page.setRequestInterception(true);
+    page.on('request', async request => {
+      if (request.isInterceptResolutionHandled()) {
         return;
       }
-      const messages = await Promise.all(
-        message.args().map(async arg => {
-          const [message, stack] = await Promise.all([
-            arg.getProperty('message'),
-            arg.getProperty('stack'),
-          ]);
 
-          let result = '';
-          if (message) {
-            result += message;
-          }
-          if (stack) {
-            result += (result.length ? '\n\n' : '') + stack;
-          }
-          return result;
-        }),
-      );
-      runtimeErrors.push(messages.filter(Boolean).join('\n'));
+      // Delegate CSP-related requests to the AutoCsp class
+      const handled = await autoCsp.handleRequest(request);
+      if (!handled) {
+        // Other requests (CSS, JS, images) pass through
+        await request.continue();
+      }
     });
 
-    page.on('pageerror', error => {
-      progressLog('error', 'Page error', error.message);
-      runtimeErrors.push(error.toString());
+    await page.goto(hostUrl, {
+      waitUntil: 'networkidle0',
+      timeout: 30000,
     });
 
-    await page.setViewport({width: 1280, height: 720});
-
-    // Set up auto-CSP handling if enabled for the environment.
-    if (enableAutoCsp) {
-      const autoCsp = new AutoCsp();
-      await autoCsp.connectToDevTools(page);
-      await page.setRequestInterception(true);
-      page.on('request', async request => {
-        if (request.isInterceptResolutionHandled()) {
-          return;
-        }
-
-        // Delegate CSP-related requests to the AutoCsp class
-        const handled = await autoCsp.handleRequest(request);
-        if (!handled) {
-          // Other requests (CSS, JS, images) pass through
-          await request.continue();
-        }
-      });
-
-      await page.goto(hostUrl, {
-        waitUntil: 'networkidle0',
-        timeout: 30000,
-      });
-
-      // Now that the page is loaded, process the collected CSP reports.
-      autoCsp.processViolations();
-      cspViolations = autoCsp.violations;
-    } else {
-      // If CSP is not enabled, just navigate to the page directly.
-      await page.goto(hostUrl, {
-        waitUntil: 'networkidle0',
-        timeout: 30000,
-      });
-    }
-
-    // Perform Axe Testing
-    if (includeAxeTesting) {
-      try {
-        progressLog('eval', `Running Axe accessibility test from ${hostUrl}`);
-        const axeResults = await new AxePuppeteer(page).analyze();
-        axeViolations = axeResults.violations;
-        progressLog('success', `Axe accessibility test completed.`);
-
-        if (axeViolations.length > 0) {
-          progressLog('error', `Found ${axeViolations.length} Axe violations.`);
-        } else {
-          progressLog('success', `No Axe violations found.`);
-        }
-      } catch (axeError: any) {
-        progressLog('error', 'Could not perform Axe accessibility test', axeError.message);
-      }
-    }
-
-    if (takeScreenshots) {
-      progressLog('eval', `Taking screenshot from ${hostUrl}`);
-
-      screenshotBase64Data = await callWithTimeout(
-        `Taking screenshot for ${appName}`,
-        () =>
-          page.screenshot({
-            type: 'png',
-            fullPage: true,
-            encoding: 'base64',
-          }),
-        1, // 1 minute
-      );
-      progressLog('success', 'Screenshot captured and encoded');
-    }
-
-    if (includeLighthouseData) {
-      try {
-        progressLog('eval', `Gathering Lighthouse data from ${hostUrl}`);
-        lighthouseResult = await getLighthouseData(hostUrl, page);
-
-        if (lighthouseResult) {
-          progressLog('success', 'Lighthouse data has been collected');
-        } else {
-          progressLog('error', 'Lighthouse did not produce usable data');
-        }
-      } catch (lighthouseError: any) {
-        progressLog('error', 'Could not gather Lighthouse data', lighthouseError.message);
-      }
-    }
-
-    await browser.close();
-  } catch (screenshotError: any) {
-    let details: string = screenshotError.message;
-
-    if (screenshotError.stack) {
-      details += '\n' + screenshotError.stack;
-    }
-
-    progressLog('error', 'Could not take screenshot', details);
+    // Now that the page is loaded, process the collected CSP reports.
+    autoCsp.processViolations();
+    cspViolations = autoCsp.violations;
+  } else {
+    // If CSP is not enabled, just navigate to the page directly.
+    await page.goto(hostUrl, {
+      waitUntil: 'networkidle0',
+      timeout: 30000,
+    });
   }
 
-  return {screenshotBase64Data, runtimeErrors, axeViolations, cspViolations, lighthouseResult};
+  // Perform Axe Testing
+  if (includeAxeTesting) {
+    try {
+      progressLog('eval', `Running Axe accessibility test from ${hostUrl}`);
+      const axeResults = await new AxePuppeteer(page).analyze();
+      axeViolations = axeResults.violations;
+      progressLog('success', `Axe accessibility test completed.`);
+
+      if (axeViolations.length > 0) {
+        progressLog('error', `Found ${axeViolations.length} Axe violations.`);
+      } else {
+        progressLog('success', `No Axe violations found.`);
+      }
+    } catch (axeError: any) {
+      progressLog('error', 'Could not perform Axe accessibility test', axeError.message);
+    }
+  }
+
+  if (takeScreenshots) {
+    progressLog('eval', `Taking screenshot from ${hostUrl}`);
+
+    screenshotBase64Data = await callWithTimeout(
+      `Taking screenshot for ${appName}`,
+      () =>
+        page.screenshot({
+          type: 'png',
+          fullPage: true,
+          encoding: 'base64',
+        }),
+      1, // 1 minute
+    );
+    progressLog('success', 'Screenshot captured and encoded');
+  }
+
+  if (includeLighthouseData) {
+    try {
+      progressLog('eval', `Gathering Lighthouse data from ${hostUrl}`);
+      lighthouseResult = await getLighthouseData(hostUrl, page);
+
+      if (lighthouseResult) {
+        progressLog('success', 'Lighthouse data has been collected');
+      } else {
+        progressLog('error', 'Lighthouse did not produce usable data');
+      }
+    } catch (lighthouseError: any) {
+      progressLog('error', 'Could not gather Lighthouse data', lighthouseError.message);
+    }
+  }
+
+  await browser.close();
+
+  return {
+    screenshotBase64Data,
+    runtimeErrors,
+    axeViolations,
+    cspViolations,
+    lighthouseResult,
+    unexpectedErrorMessage,
+  };
 }


### PR DESCRIPTION
We currently catch errors for Puppeteer logic (screenshot, runtime error collection, CSP testing etc.). The error message logged is actually wrongly saying something about screenshots.

In addition, we don't even report the error back to the worker "host". This means that the error is simply swallowed and there is empty serve testing result. We should surface the error properly by removing the `try/catch` and letting the try/catch in `worker.ts` catch the error --> so that it sets the `serveTestingResult#errorMessage`.