### PR TITLE
feat: add support for rating overrides

### DIFF
--- a/runner/configuration/environment-config.ts
+++ b/runner/configuration/environment-config.ts
@@ -1,7 +1,7 @@
 import z from 'zod';
 import {createMessageBuilder, fromError} from 'zod-validation-error/v3';
 import {UserFacingError} from '../utils/errors.js';
-import {ratingOverrideSchema, ratingSchema} from '../ratings/rating-types.js';
+import {RatingCategory, ratingOverrideSchema, ratingSchema} from '../ratings/rating-types.js';
 import {EvalPrompt, EvalPromptWithMetadata, MultiStepPrompt} from './prompts.js';
 import {executorSchema} from '../orchestration/executors/executor.js';
 import {
@@ -77,6 +77,20 @@ export const environmentConfigSchema = z.object({
       'Executor to be used for this environment. ' +
         'If unset, a local executor is derived from the full environment configuration.',
     ),
+
+  /**
+   * Map used to override fields for specific rating categories. The key is the unique ID of
+   * the category and the value are the override fields.
+   */
+  categoryOverrides: z
+    .record(
+      z.custom<RatingCategory>(),
+      z.object({
+        name: z.string().optional(),
+        maxPoints: z.number().optional(),
+      }),
+    )
+    .optional(),
 });
 
 /**

--- a/runner/ratings/rate-code.ts
+++ b/runner/ratings/rate-code.ts
@@ -19,9 +19,7 @@ import {
   PerFileRatingContentType,
   RatingKind,
   RatingCategory,
-  POINTS_FOR_CATEGORIES,
   Rating,
-  CATEGORY_NAMES,
   RatingsResult,
 } from './rating-types.js';
 import {extractEmbeddedCodeFromTypeScript} from './embedded-languages.js';
@@ -82,10 +80,9 @@ export async function rateGeneratedCode(
     RatingCategory.MEDIUM_IMPACT,
     RatingCategory.LOW_IMPACT,
   ].map(category => ({
+    ...environment.ratingCategories[category],
     id: category,
-    name: CATEGORY_NAMES[category],
     points: 0,
-    maxPoints: POINTS_FOR_CATEGORIES[category],
     assessments: [],
   }));
 

--- a/runner/ratings/rating-types.ts
+++ b/runner/ratings/rating-types.ts
@@ -32,20 +32,6 @@ export enum RatingCategory {
   LOW_IMPACT = 'low-impact',
 }
 
-/** Points correspond to each `RatingCategory`. */
-export const POINTS_FOR_CATEGORIES = {
-  [RatingCategory.HIGH_IMPACT]: 60,
-  [RatingCategory.MEDIUM_IMPACT]: 30,
-  [RatingCategory.LOW_IMPACT]: 10,
-};
-
-/** Display names for each `RatingCategory`. */
-export const CATEGORY_NAMES = {
-  [RatingCategory.HIGH_IMPACT]: 'High Impact',
-  [RatingCategory.MEDIUM_IMPACT]: 'Medium Impact',
-  [RatingCategory.LOW_IMPACT]: 'Low Impact',
-};
-
 const ratingCommonContextFields = {
   ratingsResult: z.record(z.custom<IndividualAssessment | SkippedIndividualAssessment>()),
   prompt: z.custom<PromptDefinition>(),

--- a/runner/shared-interfaces.ts
+++ b/runner/shared-interfaces.ts
@@ -174,7 +174,7 @@ export interface LlmContextFile {
 export interface AssessmentCategory {
   /** Unique ID of the category. */
   id: RatingCategory;
-  /** Display name of the cateogry. */
+  /** Display name of the category. */
   name: string;
   /** Points that have been awarded to the category. */
   points: number;


### PR DESCRIPTION
Adds a `ratingOverrides` field to the environment which makes it easier to override the weight for a specific rating without having to re-define it.