### PR TITLE
fix: include allow including angular.json and package.json in context

### DIFF
--- a/runner/orchestration/file-system.ts
+++ b/runner/orchestration/file-system.ts
@@ -174,14 +174,7 @@ export async function resolveContextFiles(
 
   const paths = globSync(patterns, {
     cwd: directory,
-    ignore: [
-      '**/node_modules/**',
-      '**/README.md',
-      '**/package-lock.json',
-      '**/package.json',
-      '**/angular.json',
-      '**/.vinxi/**',
-    ],
+    ignore: ['**/node_modules/**', '**/README.md', '**/package-lock.json', '**/.vinxi/**'],
   });
 
   return Promise.all(


### PR DESCRIPTION
These files offer valuable information to the LLM such as builder configuration, Angular version used etc..