### PR TITLE
feat: improve rendering of generated files

### DIFF
--- a/report-app/src/app/pages/report-viewer/report-viewer.html
+++ b/report-app/src/app/pages/report-viewer/report-viewer.html
@@ -535,19 +535,7 @@
                     }
 
                     <h4>Generated Code</h4>
-
-                    @for (file of attempt.outputFiles; track file) {
-                      <strong>{{ file.filePath }}</strong>
-                      <div class="util-buttons button-group">
-                        <button class="text-button" (click)="copy(file.code)">
-                          Copy source code
-                        </button>
-                        <button class="text-button" (click)="format(file)">
-                          Format source code
-                        </button>
-                      </div>
-                      <app-code-viewer [code]="formatted().get(file) ?? file.code" />
-                    }
+                    <app-file-code-viewer [files]="attempt.outputFiles" />
                   }
                 </expansion-panel>
               }

--- a/report-app/src/app/pages/report-viewer/report-viewer.ts
+++ b/report-app/src/app/pages/report-viewer/report-viewer.ts
@@ -45,6 +45,7 @@ import {ProviderLabel} from '../../shared/provider-label';
 import {AiAssistant} from '../../shared/ai-assistant/ai-assistant';
 import {LighthouseCategory} from './lighthouse-category';
 import {MultiSelect} from '../../shared/multi-select/multi-select';
+import {FileCodeViewer} from '../../shared/file-code-viewer/file-code-viewer';
 
 const localReportRegex = /-l\d+$/;
 
@@ -63,6 +64,7 @@ const localReportRegex = /-l\d+$/;
     AiAssistant,
     LighthouseCategory,
     MultiSelect,
+    FileCodeViewer,
   ],
   templateUrl: './report-viewer.html',
   styleUrls: ['./report-viewer.scss'],

--- a/report-app/src/app/shared/code-viewer.ts
+++ b/report-app/src/app/shared/code-viewer.ts
@@ -32,7 +32,7 @@ import {AppColorMode} from '../services/app-color-mode';
       content: counter(step);
       counter-increment: step;
       width: 1rem;
-      margin-right: 1.5rem;
+      margin-right: 0.5rem;
       display: inline-block;
       text-align: right;
       color: rgba(115, 138, 148, 0.4);

--- a/report-app/src/app/shared/file-code-viewer/file-code-viewer.html
+++ b/report-app/src/app/shared/file-code-viewer/file-code-viewer.html
@@ -1,0 +1,52 @@
+<div class="editor-container">
+  <div class="sidebar">
+    <div class="sidebar-header">
+      <span>Explorer</span>
+    </div>
+    <ul class="file-list">
+      @for (node of flatTree(); track node.path) {
+        @let isExpanded = node.isDirectory && node.isExpanded();
+        @let iconOptions = { isDirectory: node.isDirectory, isExpanded: isExpanded };
+
+        @if (isNodeVisible(node)) {
+          <li
+            class="file-item"
+            [class.selected]="!node.isDirectory && node === selectedFile()"
+            [class.expanded]="isExpanded"
+            (click)="toggleNode(node)"
+            [style.padding-left]="'calc(' + (node.depth * 0.5) + 'rem + var(--padding-base))'"
+            [title]="node.path"
+          >
+            @if (node.isDirectory) {
+              <span class="material-symbols-outlined collapse-indicator">chevron_right</span>
+            } @else {
+              <span class="material-symbols-outlined collapse-indicator" style="visibility: hidden;"
+                >chevron_right</span
+              >
+            }
+            <span class="material-symbols-outlined">{{ getFileIcon(node.path, iconOptions) }}</span>
+            <span class="file-name">{{ node.name }}</span>
+          </li>
+        }
+      }
+    </ul>
+  </div>
+  <div class="content">
+    @if (selectedFile(); as file) {
+      @let iconOptions = { isDirectory: false };
+      <div class="tabs">
+        <div class="tab" [title]="file.path">
+          <span class="material-symbols-outlined">{{ getFileIcon(file.path, iconOptions) }}</span>
+          <span>{{ file.name }}</span>
+        </div>
+        <button class="copy-button" (click)="copyCode()">
+          <span class="material-symbols-outlined">content_copy</span>
+          <span>Copy</span>
+        </button>
+      </div>
+      <div class="code-container">
+        <app-code-viewer [code]="file.file!.code" />
+      </div>
+    }
+  </div>
+</div>

--- a/report-app/src/app/shared/file-code-viewer/file-code-viewer.scss
+++ b/report-app/src/app/shared/file-code-viewer/file-code-viewer.scss
@@ -1,0 +1,139 @@
+:host {
+  --bg-color: #1e1e1e;
+  --sidebar-bg: #252526;
+  --border-color: #333;
+  --text-color: #cccccc;
+  --accent-color: #37373d;
+  --hover-bg: #2a2d2e;
+  --padding-base: 1rem;
+
+  display: block;
+  position: relative;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+.editor-container {
+  display: flex;
+  height: 40rem;
+  overflow: hidden;
+  background-color: var(--bg-color);
+  border-radius: 0.5rem;
+  border: 1px solid var(--border-color);
+}
+
+.sidebar {
+  width: 15rem;
+  max-width: 25rem;
+  background-color: var(--sidebar-bg);
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--border-color);
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.sidebar-header {
+  padding: calc(var(--padding-base) / 2) var(--padding-base);
+  font-weight: 600;
+  position: sticky;
+  top: 0;
+  background-color: var(--sidebar-bg);
+  z-index: 1;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  color: var(--text-color);
+}
+
+.file-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  flex-grow: 1;
+  overflow-y: auto;
+}
+
+.file-item {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem var(--padding-base);
+  cursor: pointer;
+  transition: background-color 0.2s;
+  color: var(--text-color);
+  font-size: 0.85rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  &:hover {
+    background-color: var(--hover-bg);
+  }
+
+  &.selected {
+    background-color: var(--accent-color);
+    color: white;
+  }
+}
+
+.collapse-indicator {
+  transition: transform 0.2s;
+}
+
+.file-item.expanded .collapse-indicator {
+  transform: rotate(90deg);
+}
+
+.content {
+  flex-grow: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.tabs {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: var(--sidebar-bg);
+  flex-shrink: 0;
+}
+
+.tab {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: calc(var(--padding-base) / 2) var(--padding-base);
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  border-right: 1px solid var(--sidebar-bg);
+  font-size: 0.85rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.copy-button {
+  background-color: var(--border-color);
+  color: var(--text-color);
+  border: 1px solid #444;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  margin-right: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+
+  &:hover {
+    background-color: #444;
+  }
+}
+
+.material-symbols-outlined {
+  font-size: 1rem;
+}
+
+.code-container {
+  flex-grow: 1;
+  overflow: auto;
+}

--- a/report-app/src/app/shared/file-code-viewer/file-code-viewer.ts
+++ b/report-app/src/app/shared/file-code-viewer/file-code-viewer.ts
@@ -1,0 +1,84 @@
+import {Component, computed, inject, input, linkedSignal} from '@angular/core';
+import {LlmResponseFile} from '../../../../../runner/shared-interfaces';
+import {CodeViewer} from '../code-viewer';
+import {Clipboard} from '@angular/cdk/clipboard';
+import {FileTreeNode, TreeNode, buildFileTree} from './file-tree';
+
+@Component({
+  selector: 'app-file-code-viewer',
+  templateUrl: './file-code-viewer.html',
+  styleUrl: './file-code-viewer.scss',
+  imports: [CodeViewer],
+})
+export class FileCodeViewer {
+  private readonly clipboard = inject(Clipboard);
+  readonly files = input.required<LlmResponseFile[]>();
+
+  private readonly fileTree = computed(() => buildFileTree(this.files()));
+
+  readonly flatTree = computed(() => {
+    const tree = this.fileTree();
+    const flatten = (nodes: TreeNode[]): TreeNode[] => {
+      let flat: TreeNode[] = [];
+      for (const node of nodes) {
+        flat.push(node);
+        if (node.isDirectory) {
+          flat = flat.concat(flatten(node.children));
+        }
+      }
+      return flat;
+    };
+    return flatten(tree);
+  });
+
+  readonly selectedFile = linkedSignal<FileTreeNode | undefined>(() =>
+    this.flatTree().find(f => !f.isDirectory),
+  );
+
+  toggleNode(node: TreeNode): void {
+    if (node.isDirectory) {
+      node.isExpanded.update(e => !e);
+    } else {
+      this.selectedFile.set(node);
+    }
+  }
+
+  copyCode(): void {
+    const fileNode = this.selectedFile();
+    if (fileNode?.file) {
+      if (!this.clipboard.copy(fileNode.file.code)) {
+        alert('Failed to copy code to clipboard.');
+      }
+    }
+  }
+
+  getFileIcon(filePath: string, options: {isDirectory: boolean; isExpanded?: boolean}): string {
+    if (options.isDirectory) {
+      return options.isExpanded ? 'folder_open' : 'folder';
+    }
+    const extension = filePath.split('.').pop();
+    switch (extension) {
+      case 'html':
+        return 'html';
+      case 'ts':
+        return 'javascript';
+      case 'css':
+        return 'css';
+      case 'scss':
+        return 'css';
+      default:
+        return 'article';
+    }
+  }
+
+  isNodeVisible(node: TreeNode): boolean {
+    let current = node.parent;
+    while (current && current.path) {
+      if (!current.isExpanded()) {
+        return false;
+      }
+      current = current.parent;
+    }
+    return true;
+  }
+}

--- a/report-app/src/app/shared/file-code-viewer/file-tree.ts
+++ b/report-app/src/app/shared/file-code-viewer/file-tree.ts
@@ -1,0 +1,127 @@
+import {signal, WritableSignal} from '@angular/core';
+import {LlmResponseFile} from '../../../../../runner/shared-interfaces';
+
+export interface DirectoryTreeNode {
+  isDirectory: true;
+  name: string;
+  path: string;
+  isExpanded: WritableSignal<boolean>;
+  children: (FileTreeNode | DirectoryTreeNode)[];
+  depth: number;
+  parent?: DirectoryTreeNode;
+}
+
+export interface FileTreeNode {
+  isDirectory: false;
+  name: string;
+  path: string;
+  file: LlmResponseFile;
+  depth: number;
+  parent?: DirectoryTreeNode;
+}
+
+export type TreeNode = FileTreeNode | DirectoryTreeNode;
+
+/** Creates a directory tree node. */
+function createDirectoryNode(
+  name: string,
+  path: string,
+  depth: number,
+  parent: DirectoryTreeNode | undefined,
+): DirectoryTreeNode {
+  return {
+    isDirectory: true,
+    name,
+    path,
+    isExpanded: signal(true),
+    children: [],
+    depth,
+    parent,
+  };
+}
+
+/** Creates a file tree node. */
+function createFileNode(
+  name: string,
+  path: string,
+  depth: number,
+  parent: DirectoryTreeNode | undefined,
+  file: LlmResponseFile,
+): FileTreeNode {
+  return {
+    isDirectory: false,
+    name,
+    path,
+    depth,
+    parent,
+    file,
+  };
+}
+
+/** Recursively sorts the tree, directories first, then alphabetically. */
+function sortTree(nodes: TreeNode[]): void {
+  nodes.sort((a, b) => {
+    if (a.isDirectory !== b.isDirectory) {
+      return a.isDirectory ? -1 : 1;
+    }
+    return a.name.localeCompare(b.name);
+  });
+  nodes.forEach(node => {
+    if (node.isDirectory) {
+      sortTree(node.children);
+    }
+  });
+}
+
+/** Ensures all parent directories for a given path exist in the tree. */
+function ensureDirectoryPath(pathParts: string[], nodeMap: Map<string, TreeNode>): void {
+  let currentPath = '';
+  let parentNode = nodeMap.get('')!; // Start from root
+
+  for (const part of pathParts) {
+    currentPath = currentPath ? `${currentPath}/${part}` : part;
+
+    if (!nodeMap.has(currentPath)) {
+      assertIsDirectory(parentNode, 'Expected parent node to be a directory.');
+      const newNode = createDirectoryNode(part, currentPath, parentNode.depth + 1, parentNode);
+      parentNode.children.push(newNode);
+      nodeMap.set(currentPath, newNode);
+    }
+    parentNode = nodeMap.get(currentPath)!;
+  }
+}
+
+/** Builds the file tree from a flat list of files. */
+export function buildFileTree(files: LlmResponseFile[]): TreeNode[] {
+  const root = createDirectoryNode('root', '', -1, undefined);
+  const nodeMap = new Map<string, TreeNode>([['', root]]);
+
+  for (const file of files) {
+    const pathParts = file.filePath.split('/');
+    const fileName = pathParts.pop()!;
+    const directoryPath = pathParts.join('/');
+
+    ensureDirectoryPath(pathParts, nodeMap);
+
+    const parentNode = nodeMap.get(directoryPath)!;
+    assertIsDirectory(parentNode, 'Expected parent node to be a directory.');
+
+    const fileNode = createFileNode(
+      fileName,
+      file.filePath,
+      parentNode.depth + 1,
+      parentNode,
+      file,
+    );
+    parentNode.children.push(fileNode);
+  }
+
+  sortTree(root.children);
+  return root.children;
+}
+
+function assertIsDirectory(n: TreeNode, failureMessage: string): asserts n is DirectoryTreeNode {
+  if (!n.isDirectory) {
+    throw new Error(failureMessage);
+  }
+}


### PR DESCRIPTION
Instead of rendering files one after each other, we should come up with a better editor-like representation. This is helpful as currently people need to scroll forever to e.g. get up to the error message, or when comparing between attempts.
<img width="512" height="223" alt="image" src="https://github.com/user-attachments/assets/11fbc58f-b9c1-49c2-ae94-2b0d1d530773" />
