### PR TITLE
feat: add ability to define additional analysis prompts

### DIFF
--- a/report-app/src/app/pages/report-viewer/report-viewer.html
+++ b/report-app/src/app/pages/report-viewer/report-viewer.html
@@ -225,6 +225,18 @@
       </expansion-panel>
     }
 
+    @if (report.details.summary.additionalAiAnalysis !== undefined) {
+      @for (item of report.details.summary.additionalAiAnalysis; track item) {
+        <expansion-panel size="large" class="root-section">
+          <expansion-panel-header>
+            <img src="gemini.webp" alt="Gemini Logo" height="30" width="30" />
+            {{item.name}}
+          </expansion-panel-header>
+          <div [innerHTML]="item.summary"></div>
+        </expansion-panel>
+      }
+    }
+
     @if (missingDeps().length > 0) {
       <expansion-panel size="large" class="root-section">
         <expansion-panel-header>

--- a/runner/configuration/environment-config.ts
+++ b/runner/configuration/environment-config.ts
@@ -8,6 +8,7 @@ import {
   LocalExecutorConfig,
   localExecutorConfigSchema,
 } from '../orchestration/executors/local-executor-config.js';
+import {RatingContextFilter, ReportContextFilter} from '../shared-interfaces.js';
 
 export const environmentConfigSchema = z.object({
   /** Display name for the environment. */
@@ -98,6 +99,24 @@ export const environmentConfigSchema = z.object({
    * It's useful to ensure that the set of ratings hasn't changed between two runs.
    */
   expectedRatingHash: z.string().optional(),
+
+  /**
+   * Prompts to use when for additional analysis of the eval results.
+   */
+  analysisPrompts: z
+    .array(
+      z.object({
+        name: z.string(),
+        path: z.string(),
+        reportsFilter: z
+          .enum([ReportContextFilter.AllReports, ReportContextFilter.NonPerfectReports])
+          .optional(),
+        ratingsFilter: z
+          .enum([RatingContextFilter.AllRatings, RatingContextFilter.NonPerfectRatings])
+          .optional(),
+      }),
+    )
+    .optional(),
 });
 
 /**

--- a/runner/reporting/report-ai-chat.ts
+++ b/runner/reporting/report-ai-chat.ts
@@ -87,7 +87,7 @@ ${serializeReportForPrompt(assessmentsToProcess, contextFilters)}
       includeThoughts: false,
     },
     timeout: {
-      description: `Generating summary for report`,
+      description: `Chatting with AI`,
       durationInMins: 3,
     },
     abortSignal,

--- a/runner/shared-interfaces.ts
+++ b/runner/shared-interfaces.ts
@@ -437,6 +437,8 @@ export interface RunSummary {
   completionStats?: CompletionStats;
   /** AI summary (as HTML code) of all assessments in this run/report. */
   aiSummary?: string;
+  /** Additional user-defined AI analysis. */
+  additionalAiAnalysis?: {name: string; summary: string}[];
   /**
    * Information about the runner that was used for the eval.
    * Optional since some older reports might not have it.


### PR DESCRIPTION
Adds the `analysisPrompts` field to the environment config that allows users to define their own prompts for analyzing the eval results. Example:

```
{
  // Usual config fields...
  analysisPrompts: [{name: 'Custom analysis', path: './custom-analysis.md'}]
}
```

Each of the prompts will show up like this in the report:
<img width="1226" height="758" alt="image" src="https://github.com/user-attachments/assets/0f24407d-52b9-408e-ac13-425b4fc6a3a7" />
