### PR TITLE
feat: support passing an environment programmatically

### DIFF
--- a/runner/eval-cli.ts
+++ b/runner/eval-cli.ts
@@ -209,7 +209,9 @@ async function handler(cliArgs: Arguments<Options>): Promise<void> {
     const runInfo = await generateCodeAndAssess({
       runner: cliArgs.runner,
       model: cliArgs.model,
-      environmentConfigPath: BUILT_IN_ENVIRONMENTS.get(cliArgs.environment) || cliArgs.environment,
+      environment: {
+        configPath: BUILT_IN_ENVIRONMENTS.get(cliArgs.environment) || cliArgs.environment,
+      },
       localMode: cliArgs.local,
       limit: cliArgs.limit,
       concurrency: cliArgs.concurrency as number,

--- a/runner/orchestration/generate.ts
+++ b/runner/orchestration/generate.ts
@@ -43,7 +43,11 @@ import {RatingKind} from '../ratings/rating-types.js';
  *          each containing the prompt, generated code, and final validation status.
  */
 export async function generateCodeAndAssess(options: AssessmentConfig): Promise<RunInfo> {
-  const env = await getEnvironmentByPath(options.environmentConfigPath, options.runner);
+  const env =
+    options.environment instanceof Environment
+      ? options.environment
+      : await getEnvironmentByPath(options.environment.configPath, options.runner);
+
   const extraCleanupFns: (() => Promise<void>)[] = [];
   const cleanup = async () => {
     // Clean-up should never interrupt a potentially passing completion.

--- a/runner/shared-interfaces.ts
+++ b/runner/shared-interfaces.ts
@@ -5,12 +5,13 @@ import type {AutoRateResult} from './ratings/autoraters/auto-rate-shared.js';
 import type {Rating, RatingCategory} from './ratings/rating-types.js';
 import type {ServeTestingResult} from './workers/serve-testing/worker-types.js';
 import type {RunnerName} from './codegen/runner-creation.js';
+import {Environment} from './configuration/environment.js';
 
 /** Configuration options necessary for kicking off an assessment run. */
 export interface AssessmentConfig {
   model: string;
   runner: RunnerName;
-  environmentConfigPath: string;
+  environment: Environment | {configPath: string};
   localMode: boolean;
   limit: number;
   concurrency: number | 'auto';


### PR DESCRIPTION
This is helpful for programmatic usages of WCS; supporting more "dynamic" configurations.