### PR TITLE
feat: support extension of `AiSdkRunner`

### DIFF
--- a/runner/codegen/ai-sdk/ai-sdk-model-options.ts
+++ b/runner/codegen/ai-sdk/ai-sdk-model-options.ts
@@ -1,12 +1,14 @@
 import {AnthropicProviderOptions} from '@ai-sdk/anthropic';
 import {GoogleGenerativeAIProviderOptions} from '@ai-sdk/google';
 import {OpenAIResponsesProviderOptions} from '@ai-sdk/openai';
-import {LanguageModelV3} from '@ai-sdk/provider';
+import {LanguageModelV3, SharedV3ProviderOptions} from '@ai-sdk/provider';
 
-export type ModelOptions = {
+export type AiSdkModelOptions = {
   model: LanguageModelV3;
   providerOptions:
     | {anthropic: AnthropicProviderOptions}
     | {google: GoogleGenerativeAIProviderOptions}
-    | {openai: OpenAIResponsesProviderOptions};
+    | {openai: OpenAIResponsesProviderOptions}
+    // This supports extensions of `AISdkRunner` for custom model providers.
+    | SharedV3ProviderOptions;
 };

--- a/runner/codegen/ai-sdk/anthropic.ts
+++ b/runner/codegen/ai-sdk/anthropic.ts
@@ -1,7 +1,7 @@
 import {anthropic, AnthropicProviderOptions} from '@ai-sdk/anthropic';
 import {wrapLanguageModel} from 'ai';
 import {anthropicThinkingWithStructuredResponseMiddleware} from './anthropic_thinking_patch.js';
-import {ModelOptions} from './ai-sdk-model-options.js';
+import {AiSdkModelOptions} from './ai-sdk-model-options.js';
 
 export const ANTHROPIC_MODELS = [
   'claude-opus-4.1-no-thinking',
@@ -17,7 +17,7 @@ export const ANTHROPIC_MODELS = [
 
 export async function getAiSdkModelOptionsForAnthropic(
   rawModelName: string,
-): Promise<ModelOptions | null> {
+): Promise<AiSdkModelOptions | null> {
   const modelName = rawModelName as (typeof ANTHROPIC_MODELS)[number];
 
   switch (modelName) {

--- a/runner/codegen/ai-sdk/google.ts
+++ b/runner/codegen/ai-sdk/google.ts
@@ -1,5 +1,5 @@
 import {google, GoogleGenerativeAIProviderOptions} from '@ai-sdk/google';
-import {ModelOptions} from './ai-sdk-model-options.js';
+import {AiSdkModelOptions} from './ai-sdk-model-options.js';
 
 export const GOOGLE_MODELS = [
   'gemini-2.5-flash-lite',
@@ -13,7 +13,7 @@ export const GOOGLE_MODELS = [
 
 export async function getAiSdkModelOptionsForGoogle(
   rawModelName: string,
-): Promise<ModelOptions | null> {
+): Promise<AiSdkModelOptions | null> {
   const modelName = rawModelName as (typeof GOOGLE_MODELS)[number];
 
   switch (modelName) {

--- a/runner/codegen/ai-sdk/openai.ts
+++ b/runner/codegen/ai-sdk/openai.ts
@@ -1,5 +1,5 @@
 import {openai, OpenAIResponsesProviderOptions} from '@ai-sdk/openai';
-import {ModelOptions} from './ai-sdk-model-options.js';
+import {AiSdkModelOptions} from './ai-sdk-model-options.js';
 
 export const OPENAI_MODELS = [
   'gpt-5.1-no-thinking',
@@ -10,7 +10,7 @@ export const OPENAI_MODELS = [
 
 export async function getAiSdkModelOptionsForOpenAI(
   rawModelName: string,
-): Promise<ModelOptions | null> {
+): Promise<AiSdkModelOptions | null> {
   const modelName = rawModelName as (typeof OPENAI_MODELS)[number];
 
   switch (modelName) {

--- a/runner/codegen/runner-creation.ts
+++ b/runner/codegen/runner-creation.ts
@@ -4,11 +4,11 @@ import type {ClaudeCodeRunner} from './claude-code-runner.js';
 import type {GenkitRunner} from './genkit/genkit-runner.js';
 import type {CodexRunner} from './codex-runner.js';
 import type {NoopUnimplementedRunner} from './noop-unimplemented-runner.js';
-import {AiSDKRunner} from './ai-sdk/ai-sdk-runner.js';
+import {AiSdkRunner} from './ai-sdk/ai-sdk-runner.js';
 
 interface AvailableRunners {
   genkit: GenkitRunner;
-  'ai-sdk': AiSDKRunner;
+  'ai-sdk': AiSdkRunner;
   'gemini-cli': GeminiCliRunner;
   'claude-code': ClaudeCodeRunner;
   'codex': CodexRunner;
@@ -31,7 +31,7 @@ export async function getRunnerByName<T extends RunnerName>(name: T): Promise<Av
       );
     case 'ai-sdk':
       return import('./ai-sdk/ai-sdk-runner.js').then(
-        m => new m.AiSDKRunner() as AvailableRunners[T],
+        m => new m.AiSdkRunner() as AvailableRunners[T],
       );
     case 'gemini-cli':
       return import('./gemini-cli-runner.js').then(

--- a/runner/index.ts
+++ b/runner/index.ts
@@ -52,3 +52,5 @@ export {replaceAtReferencesInPrompt} from './utils/prompt-at-references.js';
 export {extractRubrics} from './utils/extract-rubrics.js';
 export {combineReports} from './utils/combine-reports.mjs';
 export {writeReportToDisk} from './reporting/report-logging.js';
+export {AiSdkRunner} from './codegen/ai-sdk/ai-sdk-runner.js';
+export {type AiSdkModelOptions as AiSDKModelOptions} from './codegen/ai-sdk/ai-sdk-model-options.js';

--- a/runner/orchestration/executors/local-executor.ts
+++ b/runner/orchestration/executors/local-executor.ts
@@ -36,9 +36,12 @@ export class LocalExecutor implements Executor {
 
   constructor(
     public config: LocalExecutorConfig,
-    runnerName: RunnerName = 'noop-unimplemented',
+    runnerOrName: RunnerName | LlmRunner = 'noop-unimplemented',
   ) {
-    this.llm = getRunnerByName(runnerName);
+    this.llm =
+      typeof runnerOrName === 'string'
+        ? getRunnerByName(runnerOrName)
+        : Promise.resolve(runnerOrName);
   }
 
   async initializeEval(_prompt: RootPromptDefinition): Promise<EvalID> {


### PR DESCRIPTION
Supports extension of `AiSdkRunner` to wire up custom model providers, like requested in  #221

```ts
// env.config.mjs
...

class OllamaRunner extend AiSdkRunner {
  override getAiSdkModelOptions(request: LocalLlmGenerateTextRequestOptions): Promise<AiSdkModelOptions> {
     if (<.. model is your custom one>) {
        ...
     }
     return super.getAiSdkModelOptions(request);
  }

}

executor = new LocalExecutor({config}, new OllamaRunner())
```

Fixes https://github.com/angular/web-codegen-scorer/issues/221