### PR TITLE
fix: color mode service always detecting dark mode

### DIFF
--- a/report-app/src/app/services/app-color-mode.ts
+++ b/report-app/src/app/services/app-color-mode.ts
@@ -20,7 +20,7 @@ export class AppColorMode {
       } catch {}
 
       if (!colorMode) {
-        colorMode = matchMedia('(prefers-color-scheme: dark)') ? 'dark' : 'light';
+        colorMode = matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
       }
 
       this.setColorMode(colorMode);


### PR DESCRIPTION
We weren't reading the `matches` property from `matchMedia` which meant that the condition is always true.