### PR TITLE
ci: configure Renovate disable post-upgrade tasks

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>angular/dev-infra//renovate-presets/default.json5"],
   "baseBranchPatterns": ["main"],
-  "postUpgradeTasks": {}
+  "packageRules": [
+    {
+      "matchManagers": ["*"],
+      "postUpgradeTasks": {}
+    }
+  ]
 }


### PR DESCRIPTION
This repo is not managed by Bazel and thus the post-update tasks are not needed.