### PR TITLE
fix: display OpenAI icon for GPT model names in report app

### DIFF
--- a/report-app/src/app/shared/provider-label.ts
+++ b/report-app/src/app/shared/provider-label.ts
@@ -69,7 +69,7 @@ export class ProviderLabel {
 function getModelLogoURL(id: string): string | null {
   if (id.startsWith('gemini')) {
     return 'gemini.webp';
-  } else if (id.startsWith('openai')) {
+  } else if (id.startsWith('openai') || id.startsWith('gpt')) {
     return 'open-ai.png';
   } else if (id.startsWith('claude')) {
     return 'claude.png';


### PR DESCRIPTION
The provider label component only matched models starting with 'openai' but GPT models use a 'gpt-' prefix, causing them to render without an icon.